### PR TITLE
refactor: split deploy vs validate workflows, remove push triggers

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,5 +1,6 @@
 # Deploys the workshop web application to AKS.
 # Substitutes Azure resource values into K8s manifests and applies them.
+# Manual dispatch only — ensures the workload name matches your actual deployment.
 name: Deploy Application
 
 on:
@@ -9,9 +10,6 @@ on:
         description: 'Workload name (must match the infra deployment)'
         type: string
         default: srelab
-  push:
-    branches: [main]
-    paths: ['k8s/**']
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,8 +1,6 @@
 # Deploys Bicep infrastructure (AKS, CosmosDB, monitoring, identity) to Azure.
-# Triggers on manual dispatch or when infra files change on main.
-# IMPORTANT: The push trigger on infra/** is critical for the workshop —
-# when attendees remove the role assignment in Module 5 and push to main,
-# this workflow auto-deploys the broken Bicep, triggering the fault scenario.
+# Manual dispatch only — participants choose their region and workload name explicitly.
+# Push-based validation (syntax check + what-if) is handled by validate-infra.yml.
 name: Deploy Infrastructure
 
 on:
@@ -20,9 +18,6 @@ on:
         description: 'Workload name (used in resource naming)'
         type: string
         default: srelab
-  push:
-    branches: [main]
-    paths: ['infra/**']
 
 permissions:
   id-token: write

--- a/.github/workflows/validate-infra.yml
+++ b/.github/workflows/validate-infra.yml
@@ -1,0 +1,56 @@
+# Validates Bicep infrastructure on push and pull requests.
+# Runs syntax validation (no Azure credentials needed) and optionally
+# a what-if deployment preview when Azure credentials are configured.
+name: Validate Infrastructure
+
+on:
+  push:
+    branches: [main]
+    paths: ['infra/**']
+  pull_request:
+    paths: ['infra/**']
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      LOCATION: ${{ vars.AZURE_LOCATION || 'eastus2' }}
+      WORKLOAD: ${{ vars.WORKLOAD_NAME || 'srelab' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Bicep syntax
+        run: az bicep build --file infra/bicep/main.bicep --stdout > /dev/null
+
+      - name: Azure Login
+        id: azure-login
+        uses: azure/login@v2
+        continue-on-error: true
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: What-If deployment preview
+        if: steps.azure-login.outcome == 'success'
+        run: |
+          echo "============================================"
+          echo "  What-If Preview"
+          echo "  Resource Group: rg-${{ env.WORKLOAD }}"
+          echo "  Location:       ${{ env.LOCATION }}"
+          echo "============================================"
+
+          az deployment group what-if \
+            --resource-group "rg-${{ env.WORKLOAD }}" \
+            --template-file infra/bicep/main.bicep \
+            --parameters infra/bicep/main.bicepparam \
+              location="${{ env.LOCATION }}" \
+              workloadName="${{ env.WORKLOAD }}"
+
+      - name: Skip notice
+        if: steps.azure-login.outcome != 'success'
+        run: |
+          echo "::notice::Azure credentials not configured — skipped what-if preview. Bicep syntax validation passed."

--- a/docs/00-prerequisites.md
+++ b/docs/00-prerequisites.md
@@ -156,9 +156,9 @@ Your fork needs the service principal credentials as a GitHub Actions secret. An
 
 > **Security note:** GitHub encrypts these secrets in transit and at rest. They're only exposed to workflows running in your repository and cannot be read back via the GitHub UI.
 
-## Step 4: Configure Repository Variables (Required for Push-Triggered Workflows)
+## Step 4: Configure Repository Variables (Optional)
 
-When workflows trigger automatically on `push` (e.g., the fault injection scenario in Module 5), they cannot read manual `workflow_dispatch` inputs. Repository variables ensure all workflows use the correct workload name and location, regardless of how they're triggered.
+Repository variables provide default values for your workflows and the validation what-if preview. While deploy workflows always let you pick the region and workload name explicitly, setting these variables means the `Validate Infrastructure` workflow (which runs on push and PRs) can show an accurate what-if preview against your actual environment.
 
 **Steps:**
 
@@ -169,10 +169,10 @@ When workflows trigger automatically on `push` (e.g., the fault injection scenar
 
 | Variable Name | Value | Description |
 |---------------|-------|-------------|
-| `WORKLOAD_NAME` | Your chosen workload name (e.g., `srelab`) | Used in all resource naming — must match what you used in Module 1 |
-| `AZURE_LOCATION` | Your chosen Azure region (e.g., `eastus2`) | Must match the region used in Module 1 |
+| `WORKLOAD_NAME` | Your chosen workload name (e.g., `srelab`) | Used in resource naming — should match what you used in Module 1 |
+| `AZURE_LOCATION` | Your chosen Azure region (e.g., `eastus2`) | Should match the region used in Module 1 |
 
-> **Why this matters:** Without these variables, push-triggered workflows fall back to the default `srelab` / `eastus2`. If you customized your workload name during the infrastructure deployment, the app deployment and Module 5 fault injection will target the wrong resource group and fail.
+> **Why this matters:** The `Validate Infrastructure` workflow runs automatically when you push Bicep changes or open a PR. It validates Bicep syntax and shows a what-if preview of what the deployment would change. Without these variables, the what-if preview targets the default `srelab` / `eastus2`, which may not match your actual deployment.
 
 ## Step 5: Verify Your Setup
 

--- a/docs/01-deploy-infrastructure.md
+++ b/docs/01-deploy-infrastructure.md
@@ -69,7 +69,7 @@ Registration is typically instant but can take up to a few minutes. Wait for all
 
 ## Run the Deployment
 
-Choose one of the two deployment options below. **Option A (GitHub Actions) is recommended** for the full workshop experience, as the push trigger enables the Module 5 fault injection scenario. Option B is useful for local testing and development.
+Choose one of the two deployment options below. **Option A (GitHub Actions) is recommended** for the full workshop experience. Option B is useful for local testing and development.
 
 ### Option A: GitHub Actions (Recommended)
 
@@ -239,7 +239,7 @@ echo "Save this for Module 2: $UAMI_CLIENT_ID"
 ```
 
 **Note on GitHub Actions vs. Local Deployment:**  
-The GitHub Actions workflow includes a push trigger on `infra/**` changes. This is essential for **Module 5** (Break It), where you'll remove a Bicep role assignment and push to main. The workflow automatically re-deploys the broken infrastructure, triggering the fault scenario. If deploying locally, you can still complete Module 5 by re-running the deployment commands after making the Bicep change, or by using GitHub Actions for that module only.
+The `Deploy Infrastructure` workflow is triggered manually via `workflow_dispatch`. After making Bicep changes (like in Module 5), you push your code and then manually trigger the deployment — this ensures you always deploy with the correct region and workload name. A separate `Validate Infrastructure` workflow runs automatically on push and PRs to check Bicep syntax and show a what-if preview. If deploying locally, you can still complete Module 5 by re-running the deployment commands after making the Bicep change.
 
 ## Verify Resources in Azure
 

--- a/docs/05-break-it.md
+++ b/docs/05-break-it.md
@@ -6,7 +6,7 @@ Time to introduce a realistic infrastructure fault. You'll remove a critical rol
 
 ## The Scenario
 
-> _A team member is reviewing the Bicep code during a cleanup initiative. They spot a role assignment on the CosmosDB account that they think might be leftover from an old project. No one is sure if it's needed, so they remove it, commit the change, and submit a PR. The code review looks good — the Bicep is syntactically valid. The PR gets merged. The `deploy-infra` workflow triggers automatically. The infrastructure update completes successfully._
+> _A team member is reviewing the Bicep code during a cleanup initiative. They spot a role assignment on the CosmosDB account that they think might be leftover from an old project. No one is sure if it's needed, so they remove it, commit the change, and submit a PR. The code review looks good — the Bicep is syntactically valid. The PR gets merged. The team deploys the updated infrastructure. The deployment completes successfully._
 >
 > _Everything looks fine. The pods are running, health checks pass. But users start complaining that items aren't loading. The app is broken, and it happened silently._
 
@@ -64,11 +64,12 @@ git commit -m "cleanup: remove unused CosmosDB role assignment"
 git push origin main
 ```
 
-The `deploy-infra.yml` workflow will trigger automatically (it watches for changes to files in the `infra/**` path).
+When you push, the `Validate Infrastructure` workflow runs automatically — it checks Bicep syntax and shows a what-if preview of the changes. But it doesn't deploy anything. To actually deploy the broken infrastructure:
 
 1. **Go to GitHub** → your fork → **Actions** tab
-2. **Select the workflow run** for "Deploy Infra" that just started
-3. **Watch it complete** (~3–5 minutes)
+2. **Select "Deploy Infrastructure"** in the left sidebar
+3. **Click "Run workflow"** → choose your region and workload name → **Run workflow**
+4. **Watch it complete** (~3–5 minutes)
 
 The deployment will **succeed**. The Bicep template is valid syntactically. No errors. No warnings. Just a silent infrastructure change.
 
@@ -164,7 +165,7 @@ Your Azure Monitor alert will detect the spike in failed requests. The SRE Agent
 5. **Read the Bicep code** to understand what changed
 6. **Identify the root cause:** missing role assignment
 7. **Propose a fix** and open a PR on your fork
-8. **If you configured it for Autonomous mode,** the agent will merge the PR and trigger a new deployment
+8. **If you configured it for Autonomous mode,** the agent will merge the PR — you then trigger the `Deploy Infrastructure` workflow to apply the fix
 
 You don't need to fix this yourself. **Don't troubleshoot.** Don't manually restore the role assignment. Let the SRE Agent do its job. Head to Module 6 to watch it work.
 

--- a/docs/06-watch-sre-agent.md
+++ b/docs/06-watch-sre-agent.md
@@ -280,12 +280,12 @@ Click on the **"Files changed"** tab:
 2. Confirm the merge
 3. Optionally delete the branch after merging
 
-### Step 2: Watch the deployment
+### Step 2: Deploy the fix
 1. Go to your repository's **Actions** tab
-2. Look for `deploy-infra.yml` workflow running
-   - GitHub Actions automatically triggered when you merged
-   - This workflow deploys the Bicep changes to Azure
-3. Wait for the workflow to complete (~3–5 minutes)
+2. Select **"Deploy Infrastructure"** in the left sidebar
+3. Click **"Run workflow"** → choose your region and workload name → **Run workflow**
+   - This deploys the Bicep changes (with the restored role assignment) to Azure
+4. Wait for the workflow to complete (~3–5 minutes)
    - You should see a ✅ green checkmark when done
 
 ### Step 3: Verify the app is working again
@@ -406,7 +406,8 @@ Module 5 — 14:32:15
   └─ Push to main
 
 Module 5 — 14:32:47
-  └─ GitHub Actions: deploy-infra.yml triggered
+  └─ Validate Infrastructure workflow runs (syntax + what-if)
+  └─ You: Manually trigger Deploy Infrastructure workflow
   └─ Bicep deploys infrastructure WITHOUT role assignment
   └─ CosmosDB still exists, but managed identity has no permission
 
@@ -447,7 +448,7 @@ Module 6 — 14:39:15 (Your Action)
   └─ You: Confirm merge
 
 Module 6 — 14:39:22 (Redeployment)
-  └─ GitHub Actions: deploy-infra.yml triggered (post-merge)
+  └─ You: Manually trigger Deploy Infrastructure workflow
   └─ Bicep deploys infrastructure WITH role assignment restored
   └─ CosmosDB role assignment is recreated
   └─ Managed identity regains permission
@@ -482,7 +483,7 @@ What you just experienced is the **full incident lifecycle**, compressed into 10
 | **Diagnosis** | Synthesize findings into incident post-mortem (next day) | Synthesized during incident response (minutes) |
 | **Fix proposal** | Senior engineer codes a fix during incident (error-prone) | Automated code fix based on diagnosis |
 | **Code review** | Peer review process (standard PR flow) | You review SRE Agent PR |
-| **Deployment** | CI/CD runs automatically post-merge | CI/CD runs automatically post-merge |
+| **Deployment** | CI/CD runs automatically post-merge | You trigger Deploy Infrastructure after merging |
 | **Verification** | Manual spot-checking, "Is it fixed?" | Automated health check validation |
 | **Incident closure** | Manual investigation report written next day | Incident marked resolved with full analysis attached |
 | **MTTR** | 30–60+ minutes | 5–10 minutes |


### PR DESCRIPTION
## Problem

When participants fork the repo and deploy to a non-default region (e.g. `swedencentral`), push-triggered deploys silently fall back to `eastus2` because `inputs.location` is undefined on push events. This causes infrastructure to deploy to the wrong region.

## Changes

### Workflows
- **`deploy-infra.yml`** — removed push trigger, now `workflow_dispatch` only. Participants always explicitly choose their region and workload name.
- **`deploy-app.yml`** — removed push trigger, now `workflow_dispatch` only (same rationale: workload name mismatch risk).
- **`validate-infra.yml`** (new) — runs on push + PRs to `infra/**`. Validates Bicep syntax (`az bicep build`) and runs an optional `what-if` preview when Azure credentials are configured. Gracefully skips the what-if step in forks without credentials.
- **`publish-image.yml`** — unchanged (image publishing is region-independent).

### Docs
- **`00-prerequisites.md`** — repo variables changed from "Required" to "Optional"; rewrote rationale to reflect the new validation workflow.
- **`01-deploy-infrastructure.md`** — removed references to push trigger being essential; updated the local-vs-Actions note.
- **`05-break-it.md`** — updated scenario narrative, deploy instructions (manual trigger), and SRE Agent autonomous mode text.
- **`06-watch-sre-agent.md`** — updated merge/deploy steps, full timeline diagram, and comparison table.

## Trade-offs

- Participants need one extra click (manual workflow trigger) after pushing or merging the SRE Agent's fix PR.
- The what-if on PRs is actually more educational: when the SRE Agent opens its fix PR, the what-if output shows exactly what the Bicep change restores.