### PR TITLE
docs: rename Knowledge Files to Knowledge Sources in module 3

### DIFF
--- a/workshops/aks/docs/03-onboard-sre-agent.md
+++ b/workshops/aks/docs/03-onboard-sre-agent.md
@@ -104,12 +104,12 @@ With access to your resource group, the agent can:
 - Inspect **resource configurations** (Bicep deployment history, role assignments, secrets)
 - Correlate **deployment changes** with performance degradation
 
-## Upload Knowledge Files
+## Upload Knowledge Sources
 
 The SRE Agent can ingest runbooks and operational guidelines that shape how it responds to incidents. Upload the operational guidelines file included in this repository:
 
-1. On the setup page, find the **Knowledge files** card
-2. Click the **+** button to add a knowledge document
+1. On the setup page, find the **Knowledge Sources** card
+2. Select **Add File** to upload the predefined knowledge document
 3. Upload the file `workshops/aks/knowledge/operational-guidelines.md` from your repository
 4. Wait for the green checkmark
 

--- a/workshops/appservice/docs/03-onboard-sre-agent.md
+++ b/workshops/appservice/docs/03-onboard-sre-agent.md
@@ -104,12 +104,12 @@ With access to your resource group, the agent can:
 - Inspect **resource configurations** (Bicep deployment history, role assignments)
 - Correlate **deployment changes** with performance degradation
 
-## Upload Knowledge Files
+## Upload Knowledge Sources
 
 The SRE Agent can ingest runbooks and operational guidelines that shape how it responds to incidents. Upload the operational guidelines file included in this repository:
 
-1. On the setup page, find the **Knowledge files** card
-2. Click the **+** button to add a knowledge document
+1. On the setup page, find the **Knowledge Sources** card
+2. Select **Add File** to upload the predefined knowledge document
 3. Upload the file `workshops/appservice/knowledge/operational-guidelines.md` from your repository
 4. Wait for the green checkmark
 


### PR DESCRIPTION
## What

The Azure SRE Agent GUI renamed the onboarding card from **Knowledge files** to **Knowledge Sources**, and uploading now uses an **Add File** action instead of a **+** button. This updates the module 3 onboarding instructions to match the current GUI.

Verified against the issue's screenshot (live provisioned sample) and the current Microsoft Learn SRE Agent docs.

## Changes

Updated the *Upload Knowledge* section in module 3 for both affected tracks (identical wording, fixed both to avoid drift):
- `workshops/aks/docs/03-onboard-sre-agent.md`
- `workshops/appservice/docs/03-onboard-sre-agent.md`

| Before | After |
|---|---|
| `## Upload Knowledge Files` | `## Upload Knowledge Sources` |
| find the **Knowledge files** card | find the **Knowledge Sources** card |
| Click the **+** button to add a knowledge document | Select **Add File** to upload the predefined knowledge document |

Fixes #8