### PR TITLE
feat(codespaces): per-track dev containers for AKS, VM, and App Service

### DIFF
--- a/.devcontainer/aks/devcontainer.json
+++ b/.devcontainer/aks/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "SRE Workshop — AKS",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/azure-cli:1": { "installBicep": true },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": { "helm": "none", "minikube": "none" }
+  },
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y jq",
+  "postCreateCommand": "npm --prefix scripts/scenario-tools ci && npm --prefix workshops/aks/src/app ci",
+  "forwardPorts": [3000],
+  "hostRequirements": { "cpus": 4 },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-vscode.azurecli",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat",
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}

--- a/.devcontainer/appservice/devcontainer.json
+++ b/.devcontainer/appservice/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "SRE Workshop — App Service",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/azure-cli:1": { "installBicep": true },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/dotnet:2": { "version": "10.0" }
+  },
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y jq",
+  "postCreateCommand": "npm --prefix scripts/scenario-tools ci && dotnet restore workshops/appservice/src/Shop.csproj",
+  "forwardPorts": [5000],
+  "hostRequirements": { "cpus": 4 },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-vscode.azurecli",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat",
+        "ms-dotnettools.csdevkit"
+      ]
+    }
+  }
+}

--- a/.devcontainer/vm/devcontainer.json
+++ b/.devcontainer/vm/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "SRE Workshop — VM",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/azure-cli:1": { "installBicep": true },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y jq",
+  "postCreateCommand": "npm --prefix scripts/scenario-tools ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-vscode.azurecli",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ New to the Azure SRE Agent? Read the shared concept layer first:
 Each track follows the same loop: **deploy from code → inject a realistic fault →
 watch the agent investigate → apply controlled remediation → capture a postmortem.**
 
+## Open in Codespaces
+
+You can run any track in a preconfigured [GitHub Codespace](https://docs.github.com/codespaces)
+— no local tool installation required. Each track has its own dev container under
+`.devcontainer/<track>/` bundling that track's toolchain (Azure CLI + Bicep, PowerShell,
+GitHub CLI, Node, jq, plus kubectl for AKS or .NET 10 for App Service).
+
+1. Click **Code → Codespaces → New with options…**
+2. Under **Dev container configuration**, pick your track: **SRE Workshop — AKS**,
+   **SRE Workshop — VM**, or **SRE Workshop — App Service**.
+3. Create the Codespace and wait for setup to finish.
+
+When it opens, authenticate the CLIs interactively with `az login` and `gh auth login`.
+
 ## Scenarios at a glance
 
 - AKS scenarios: [workshops/aks/scenarios/INDEX.md](workshops/aks/scenarios/INDEX.md)

--- a/docs/superpowers/plans/2026-07-27-codespaces-devcontainer-config.md
+++ b/docs/superpowers/plans/2026-07-27-codespaces-devcontainer-config.md
@@ -1,0 +1,320 @@
+# Codespaces Dev Container Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub Codespaces support via three per-track Dev Container configs (`aks`, `vm`, `appservice`) so an attendee gets a ready-to-use environment for their chosen track.
+
+**Architecture:** Each `.devcontainer/<track>/devcontainer.json` starts from `mcr.microsoft.com/devcontainers/base:ubuntu` and composes official Dev Container Features. A common baseline (Node 20, Azure CLI+Bicep, PowerShell, GitHub CLI, jq) is shared by all three; `aks` adds kubectl, `appservice` adds .NET 10. `postCreateCommand` installs repo dependencies.
+
+**Tech Stack:** Dev Container Features, Node.js 20, Azure CLI + Bicep, kubectl, PowerShell, .NET SDK 10, GitHub CLI, jq.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-codespaces-devcontainer-config-design.md`
+
+**Conventions:**
+- Files are written as **pure JSON** (no comments) so `node`/`jq` can validate them directly.
+- Validation in this repo/host uses `node` (guaranteed present); the full container build is validated in Codespaces, not locally.
+- Commit style follows the repo: `feat(codespaces): …`, `docs(codespaces): …`. Every commit includes the trailers shown in Task steps.
+
+---
+
+### Task 1: VM dev container (baseline template)
+
+The VM track needs only the common baseline. This file establishes the pattern the other two extend.
+
+**Files:**
+- Create: `.devcontainer/vm/devcontainer.json`
+
+- [ ] **Step 1: Create the directory**
+
+Run: `mkdir -p .devcontainer/vm`
+
+- [ ] **Step 2: Create `.devcontainer/vm/devcontainer.json`**
+
+```json
+{
+  "name": "SRE Workshop — VM",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/azure-cli:1": { "installBicep": true },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y jq",
+  "postCreateCommand": "npm --prefix scripts/scenario-tools ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-vscode.azurecli",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat"
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Validate the JSON parses**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/vm/devcontainer.json','utf8')); console.log('valid')"`
+Expected: `valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .devcontainer/vm/devcontainer.json
+git commit -m "feat(codespaces): add VM track dev container
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Copilot-Session: 7db6f26c-4ec9-43c6-b2d8-48f3f065fd8e"
+```
+
+---
+
+### Task 2: AKS dev container
+
+Baseline + kubectl (for `workshops/aks/k8s/*.yaml`) + Node app dependencies + port 3000 (Express app).
+
+**Files:**
+- Create: `.devcontainer/aks/devcontainer.json`
+
+- [ ] **Step 1: Create the directory**
+
+Run: `mkdir -p .devcontainer/aks`
+
+- [ ] **Step 2: Create `.devcontainer/aks/devcontainer.json`**
+
+```json
+{
+  "name": "SRE Workshop — AKS",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/azure-cli:1": { "installBicep": true },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": { "helm": "none", "minikube": "none" }
+  },
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y jq",
+  "postCreateCommand": "npm --prefix scripts/scenario-tools ci && npm --prefix workshops/aks/src/app ci",
+  "forwardPorts": [3000],
+  "hostRequirements": { "cpus": 4 },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-vscode.azurecli",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat",
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Validate the JSON parses**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/aks/devcontainer.json','utf8')); console.log('valid')"`
+Expected: `valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .devcontainer/aks/devcontainer.json
+git commit -m "feat(codespaces): add AKS track dev container
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Copilot-Session: 7db6f26c-4ec9-43c6-b2d8-48f3f065fd8e"
+```
+
+---
+
+### Task 3: App Service dev container
+
+Baseline + .NET SDK 10 (`Shop.csproj` targets `net10.0`, `global.json` pins `10.0.100`) + `dotnet restore` + port 5000 (Kestrel default).
+
+**Files:**
+- Create: `.devcontainer/appservice/devcontainer.json`
+
+- [ ] **Step 1: Create the directory**
+
+Run: `mkdir -p .devcontainer/appservice`
+
+- [ ] **Step 2: Create `.devcontainer/appservice/devcontainer.json`**
+
+```json
+{
+  "name": "SRE Workshop — App Service",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/azure-cli:1": { "installBicep": true },
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/dotnet:2": { "version": "10.0" }
+  },
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y jq",
+  "postCreateCommand": "npm --prefix scripts/scenario-tools ci && dotnet restore workshops/appservice/src/Shop.csproj",
+  "forwardPorts": [5000],
+  "hostRequirements": { "cpus": 4 },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-vscode.azurecli",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat",
+        "ms-dotnettools.csdevkit"
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Validate the JSON parses**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/appservice/devcontainer.json','utf8')); console.log('valid')"`
+Expected: `valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .devcontainer/appservice/devcontainer.json
+git commit -m "feat(codespaces): add App Service track dev container
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Copilot-Session: 7db6f26c-4ec9-43c6-b2d8-48f3f065fd8e"
+```
+
+---
+
+### Task 4: Add "Open in Codespaces" note to the root README
+
+Point attendees at the track picker. Insert a new section between the "Choose a track" loop paragraph and "## Scenarios at a glance".
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Insert the Codespaces section**
+
+Find this block in `README.md`:
+
+```markdown
+Each track follows the same loop: **deploy from code → inject a realistic fault →
+watch the agent investigate → apply controlled remediation → capture a postmortem.**
+
+## Scenarios at a glance
+```
+
+Replace it with:
+
+```markdown
+Each track follows the same loop: **deploy from code → inject a realistic fault →
+watch the agent investigate → apply controlled remediation → capture a postmortem.**
+
+## Open in Codespaces
+
+You can run any track in a preconfigured [GitHub Codespace](https://docs.github.com/codespaces)
+— no local tool installation required. Each track has its own dev container under
+`.devcontainer/<track>/` bundling that track's toolchain (Azure CLI + Bicep, PowerShell,
+GitHub CLI, Node, jq, plus kubectl for AKS or .NET 10 for App Service).
+
+1. Click **Code → Codespaces → New with options…**
+2. Under **Dev container configuration**, pick your track: **SRE Workshop — AKS**,
+   **SRE Workshop — VM**, or **SRE Workshop — App Service**.
+3. Create the Codespace and wait for setup to finish.
+
+When it opens, authenticate the CLIs interactively with `az login` and `gh auth login`.
+
+## Scenarios at a glance
+```
+
+- [ ] **Step 2: Verify the section was inserted exactly once**
+
+Run: `grep -c "## Open in Codespaces" README.md`
+Expected: `1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(codespaces): add Open in Codespaces section to README
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+Copilot-Session: 7db6f26c-4ec9-43c6-b2d8-48f3f065fd8e"
+```
+
+---
+
+### Task 5: Final verification
+
+Confirm all three configs are valid, feature IDs are consistent, and the tree is clean.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Validate all three configs parse**
+
+Run:
+```bash
+for t in vm aks appservice; do
+  node -e "JSON.parse(require('fs').readFileSync('.devcontainer/$t/devcontainer.json','utf8')); console.log('$t valid')"
+done
+```
+Expected:
+```
+vm valid
+aks valid
+appservice valid
+```
+
+- [ ] **Step 2: Confirm the shared baseline features appear in all three**
+
+Run:
+```bash
+for f in node azure-cli powershell github-cli; do
+  echo "$f: $(grep -l "features/$f:" .devcontainer/*/devcontainer.json | wc -l)"
+done
+```
+Expected (each present in all 3):
+```
+node: 3
+azure-cli: 3
+powershell: 3
+github-cli: 3
+```
+
+- [ ] **Step 3: Confirm track-specific features are scoped correctly**
+
+Run:
+```bash
+grep -l "kubectl-helm-minikube" .devcontainer/*/devcontainer.json
+grep -l "features/dotnet:" .devcontainer/*/devcontainer.json
+```
+Expected: kubectl only in `.devcontainer/aks/devcontainer.json`; dotnet only in `.devcontainer/appservice/devcontainer.json`.
+
+- [ ] **Step 4: Confirm a clean working tree**
+
+Run: `git status --porcelain`
+Expected: empty output (all changes committed).
+
+---
+
+## Post-implementation acceptance (manual, in Codespaces)
+
+Not part of the automated steps — validate once in GitHub Codespaces:
+
+- Creating a Codespace from each config builds successfully.
+- Tools resolve on `PATH`: `az`, `bicep`, `pwsh`, `gh`, `jq`, `node` in all; `kubectl` on aks; `dotnet --version` reports 10.x on appservice.
+- `scripts/validate-scenarios.sh` prints `Scenario validation passed`.

--- a/docs/superpowers/specs/2026-07-27-codespaces-devcontainer-config-design.md
+++ b/docs/superpowers/specs/2026-07-27-codespaces-devcontainer-config-design.md
@@ -1,0 +1,98 @@
+# Design — Codespaces Dev Container Configuration
+
+Add GitHub Codespaces support to the repo via **per-track Dev Container configurations**, so a
+workshop attendee can spin up a cloud dev environment preloaded with exactly the toolchain their
+chosen track (`aks`, `vm`, or `appservice`) needs to run the labs end-to-end.
+
+## Problem & Goal
+
+The repo has no `.devcontainer/`, so opening it in Codespaces yields a bare image missing the
+workshop toolchain (Azure CLI + Bicep, kubectl, PowerShell, .NET 10, Node, gh, jq). Attendees would
+have to install everything by hand before they can inject scenarios, deploy Bicep, or run the
+GitOps remediation flow.
+
+**Goal:** ship ready-to-use Codespaces configs so that "Create Codespace" gives an attendee a
+working environment for their track with zero manual tool installation.
+
+## Scope & decomposition
+
+- **In scope:** three `devcontainer.json` files (one per existing track), each composing official
+  Dev Container Features, VS Code extensions, and a `postCreate` step that installs repo
+  dependencies. Track-scoped so the Codespaces creation picker offers a clear choice.
+- **Out of scope (YAGNI / non-goals):**
+  - A single "kitchen-sink" container running all three tracks at once (rejected: attendee chose
+    per-track).
+  - Docker-in-Docker / local image builds — the AKS app image is built by `publish-aks-image.yml`
+    in CI, not locally.
+  - Baking in Azure/GitHub credentials — auth stays interactive (`az login`, `gh auth login`).
+  - Repo-level **prebuild** config (that lives in GitHub repo settings, not in `devcontainer.json`);
+    called out as an optional follow-up, not built here.
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Layout | **Per-track** `.devcontainer/<track>/devcontainer.json` (`aks`, `vm`, `appservice`) | Codespaces creation flow lets the attendee pick the config; each image carries only its track's tools. |
+| Build strategy | **Base image + official Dev Container Features** on `mcr.microsoft.com/devcontainers/base:ubuntu` | Version-pinnable, independently maintained; installs bleeding tools (.NET 10) cleanly; readable/maintainable vs. a monolithic Dockerfile. |
+| Node | `features/node` @ 20 in **all three** | scenario-tools (`scripts/scenario-tools`, ESM) validate/generate is shared framework tooling; AKS app also needs it. |
+| Azure CLI + Bicep | `features/azure-cli` with `installBicep: true`, all three | 27 `.bicep` files; deploy + `what-if` across every track. |
+| PowerShell | `features/powershell`, all three | Every scenario ships a `.ps1` alongside `.sh`; VM tools are PowerShell too. |
+| GitHub CLI | `features/github-cli`, all three | Core to the issue → `@copilot` PR GitOps remediation flow. |
+| jq | apt install in `onCreateCommand`, all three | Used by `scripts/validate-scenarios.sh` and scenario scripts; not guaranteed in base image. |
+| kubectl | `features/kubectl-helm-minikube` (kubectl only; helm/minikube `none`) — **aks only** | AKS track applies `workshops/aks/k8s/*.yaml`. |
+| .NET SDK | `features/dotnet` @ `10.0` — **appservice only** | `Shop.csproj` targets `net10.0`, `global.json` pins `10.0.100`. |
+| Credentials | Interactive at runtime | No secrets in the repo/image; matches the manual-deploy, human-in-the-loop workshop model. |
+
+## Architecture
+
+### Structure
+```
+.devcontainer/
+├── aks/devcontainer.json
+├── vm/devcontainer.json
+└── appservice/devcontainer.json
+```
+
+### Per-track tool & config matrix
+
+| | **aks** | **vm** | **appservice** |
+|---|---|---|---|
+| Base image | `base:ubuntu` | `base:ubuntu` | `base:ubuntu` |
+| Common features | node20, azure-cli(+bicep), powershell, github-cli | same | same |
+| Extra features | kubectl | — | dotnet 10.0 |
+| jq | onCreate apt | onCreate apt | onCreate apt |
+| postCreate | `npm ci` scenario-tools + `npm ci` `src/app` | `npm ci` scenario-tools | `npm ci` scenario-tools + `dotnet restore src` |
+| forwardPorts | 3000 (Express app) | — | 5000 (Kestrel) |
+| hostRequirements | cpus 4 | default | cpus 4 |
+| name | "SRE Workshop — AKS" | "SRE Workshop — VM" | "SRE Workshop — App Service" |
+
+### VS Code extensions
+
+- **Common (all three):** `ms-azuretools.vscode-bicep`, `ms-vscode.azurecli`,
+  `ms-vscode.powershell`, `github.vscode-github-actions`, `redhat.vscode-yaml`,
+  `github.copilot`, `github.copilot-chat`.
+- **aks adds:** `ms-kubernetes-tools.vscode-kubernetes-tools`, `dbaeumer.vscode-eslint`.
+- **appservice adds:** `ms-dotnettools.csdevkit`.
+
+### `postCreateCommand` notes
+
+- Both `scripts/scenario-tools` and `workshops/aks/src/app` have committed `package-lock.json` →
+  use `npm ci` (reproducible) for both.
+- Exact command form: run each install with an explicit working dir (e.g. `npm --prefix <dir> ci` or
+  a `cd … && …` chain) so it resolves regardless of the Codespace's initial CWD.
+
+## Verification / acceptance
+
+- Each `devcontainer.json` is valid JSON (JSONC comments allowed) and references only real,
+  currently-published Feature and extension IDs.
+- Feature option names (`installBicep`, dotnet `version`, kubectl-helm-minikube toggles) are checked
+  against the features' published schemas at implementation time.
+- Acceptance: a Codespace created from each config builds and lands with the track's tools on
+  `PATH` (`az`, `bicep`, `pwsh`, `gh`, `jq`, plus `kubectl` on aks / `dotnet` on appservice), and
+  `scripts/validate-scenarios.sh` runs. Full build is validated in Codespaces (Docker not assumed in
+  this local environment).
+
+## Documentation touchpoints
+
+- Add a short "Open in Codespaces" note to `README.md` (and/or per-track `workshops/<track>/README.md`)
+  pointing attendees at the track picker. Kept minimal; not a new doc page.


### PR DESCRIPTION
## Summary
- Add GitHub Codespaces support via **per-track** dev containers: `.devcontainer/{aks,vm,appservice}/devcontainer.json`. When creating a Codespace, attendees pick their track from the config picker.
- Each config composes official **Dev Container Features** on `mcr.microsoft.com/devcontainers/base:ubuntu`. Shared baseline: **Node 20, Azure CLI + Bicep, PowerShell, GitHub CLI, jq**. Track extras: **kubectl** (AKS), **.NET SDK 10** (App Service).
- `postCreateCommand` installs repo deps: `npm ci` for `scripts/scenario-tools` (all tracks), `npm ci` for the AKS Node app, `dotnet restore` for the App Service `Shop.csproj`.
- `forwardPorts` 3000 (AKS Express app) / 5000 (App Service Kestrel); `hostRequirements.cpus: 4` on the heavier AKS/App Service images.
- Add an **"Open in Codespaces"** section to `README.md` documenting the track picker and interactive `az login` / `gh auth login`.
- Design spec + implementation plan committed under `docs/superpowers/`.

## Test Plan
- [x] All three `devcontainer.json` parse as valid JSON
- [x] Shared baseline features present in all three; `kubectl` AKS-only, `dotnet` App Service-only
- [x] `scripts/scenario-tools` unit tests pass (13/13); `scripts/validate-scenarios.sh` prints `Scenario validation passed`
- [x] README track-picker names match the `name` field in each config
- [ ] Create a Codespace from each config in GitHub Codespaces; confirm `az`, `bicep`, `pwsh`, `gh`, `jq`, `node` on PATH (+ `kubectl` on AKS, `dotnet --version` 10.x on App Service) and `scripts/validate-scenarios.sh` runs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>