### PR TITLE
docs: improve Cloud Agent Handover setup guidance

### DIFF
--- a/docs/cloud-agent-handover-feedback-design-2026-08-16.md
+++ b/docs/cloud-agent-handover-feedback-design-2026-08-16.md
@@ -1,0 +1,121 @@
+# Cloud Agent Handover Feedback Design
+
+## Scope
+
+Implement the August 2026 workshop feedback for the Cloud Agent Handover
+capsule, excluding Azure DevOps Boards integration and guidance.
+
+The changes remain focused on:
+
+- `scenarios/cloud-agent-handover/docs/00-prerequisites.md`
+- `scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md`
+- `scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md`
+- `scenarios/cloud-agent-handover/docs/04-configure-incident-response.md`
+- focused scenario-tool documentation contract tests
+
+Shared GitHub connector guidance and other scenario capsules remain unchanged
+unless a link must be corrected for the handover flow.
+
+## Prerequisites and Region Guidance
+
+The prerequisites module will explicitly list the Azure resource providers
+registered by setup:
+
+- `Microsoft.Web`
+- `Microsoft.Insights`
+- `Microsoft.OperationalInsights`
+
+It will explain that the operator needs subscription permission to register
+providers when they are not already registered. The readiness checklist will
+include provider registration or permission to register them.
+
+The GitHub prerequisite will state the precise CodeQL availability rule:
+CodeQL is available for public repositories without a GitHub Code Security
+license, while private or internal participant-owned repositories require
+GitHub Code Security, historically part of GitHub Advanced Security, to run
+the workshop's CodeQL workflow.
+
+Sweden Central will be the recommended deployment region because workshop
+participants encountered quota constraints elsewhere. East US 2 and Australia
+East remain supported alternatives. Deployment examples and default guidance
+will lead with `swedencentral` without changing the setup scripts' existing
+compatibility unless implementation reveals a safe, directly related default
+change is required.
+
+## Prescriptive SRE Agent Onboarding
+
+The onboarding module will separate agent creation from data-source setup and
+provide expected values for the scenario:
+
+- subscription: the workshop subscription
+- resource group: `rg-<workload>`
+- region: Sweden Central when the infrastructure uses the recommended region,
+  otherwise the same supported deployment region
+- Application Insights: `<workload>-ai`
+- model provider and model: an available tenant-supported choice
+
+The setup guidance will describe each relevant panel and its expected outcome:
+
+| Panel | Workshop configuration |
+| --- | --- |
+| Code | Connect the generated GitHub repository and wait for a green check. |
+| Logs | Skip additional log connectors because the scenario uses the Log Analytics and Application Insights resources covered through Azure resource access. |
+| Azure Resources | Add `rg-<workload>` with Reader-level access and wait for permissions to complete. |
+| Incidents | Connect Azure Monitor so the scenario alert can create incidents. |
+
+The guide will distinguish Quickstart and Full setup where current portal
+navigation does so, explain how to return through **Complete setup**, and add a
+verification checklist for the required completed states. It will retain the
+persistent operational-guidelines upload and Team Onboarding handoff.
+
+## Incident Response Plan Flow
+
+The incident-response module will make the prerequisites explicit before plan
+creation:
+
+1. Azure Monitor is connected as the incident platform.
+2. A scenario-specific custom agent exists in Agent Canvas.
+3. The custom agent has the indexed operational guidance and only the tools
+   needed for investigation and approved GitHub issue creation.
+
+The custom-agent instructions will preserve the governance contract: diagnose
+the unfinished endpoint, do not change Azure or repository code directly,
+request approval before creating one unassigned issue, and leave Copilot
+assignment, pull-request review, merge, and deployment to the documented
+actors.
+
+The plan navigation will follow the current Microsoft flow:
+
+1. Open **Builder → Agent Canvas**.
+2. Select **Create → Trigger → Incident response plan**.
+3. Configure `cloud-agent-handover-review`, the scenario custom agent, Sev2,
+   the exact alert-title filter, Review autonomy, and the default three-hour
+   cooldown.
+4. Select **Next**, preview matches, create the plan, and verify it in the
+   response-plan grid.
+
+The guide will retain the instruction to remove the default `quickstart` plan
+to avoid duplicate routing.
+
+## Validation
+
+Focused Node tests will assert that the handover documentation retains:
+
+- all three provider namespaces
+- the public versus private/internal CodeQL licensing rule
+- Sweden Central as the recommended region
+- prescriptive coverage of Code, Logs, Azure Resources, and Incidents
+- Azure Monitor and scenario custom-agent prerequisites
+- the current Agent Canvas response-plan navigation
+- Review autonomy and the governed unassigned-issue handoff
+
+After implementation, run:
+
+```bash
+npm --prefix scripts/scenario-tools test
+scripts/validate-scenarios.sh --write
+scripts/validate-scenarios.sh
+```
+
+The generated root scenario catalog will only change if manifest-derived
+content requires regeneration.

--- a/docs/cloud-agent-handover-feedback-implementation-plan-2026-08-16.md
+++ b/docs/cloud-agent-handover-feedback-implementation-plan-2026-08-16.md
@@ -1,0 +1,444 @@
+# Cloud Agent Handover Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve the Cloud Agent Handover prerequisites, region recommendation, SRE Agent onboarding, and incident-response-plan instructions while excluding Azure DevOps Boards guidance.
+
+**Architecture:** Keep the change inside the existing scenario capsule and enforce the key workshop contracts with focused Node documentation tests. Update prerequisites and deployment guidance first, then make onboarding and incident response prescriptive using the current Microsoft portal flow.
+
+**Tech Stack:** Markdown, Node.js built-in test runner, repository scenario validation tooling
+
+---
+
+## File Structure
+
+- `scripts/scenario-tools/test/cloud-agent-handover-setup.test.js`: adds
+  regression assertions for the requested documentation outcomes.
+- `scenarios/cloud-agent-handover/docs/00-prerequisites.md`: documents provider
+  registration, CodeQL licensing, and the recommended region.
+- `scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md`: leads setup
+  commands and troubleshooting with Sweden Central.
+- `scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md`: provides exact
+  agent-creation inputs and setup-card outcomes.
+- `scenarios/cloud-agent-handover/docs/04-configure-incident-response.md`:
+  documents the Azure Monitor connection, scenario custom agent, and current
+  response-plan creation path.
+
+### Task 1: Add Failing Documentation Contracts
+
+**Files:**
+- Modify: `scripts/scenario-tools/test/cloud-agent-handover-setup.test.js`
+
+- [ ] **Step 1: Add prerequisite and region contract tests**
+
+Append:
+
+```javascript
+test('Cloud Agent Handover documents providers, CodeQL licensing, and recommended region', () => {
+  const scenarioRoot = resolve(repositoryRoot, 'scenarios/cloud-agent-handover');
+  const prerequisites = readFileSync(
+    resolve(scenarioRoot, 'docs/00-prerequisites.md'),
+    'utf8'
+  );
+  const deploymentGuide = readFileSync(
+    resolve(scenarioRoot, 'docs/01-deploy-infrastructure.md'),
+    'utf8'
+  );
+
+  for (const provider of [
+    'Microsoft.Web',
+    'Microsoft.Insights',
+    'Microsoft.OperationalInsights',
+  ]) {
+    assert.match(prerequisites, new RegExp(provider.replace('.', '\\.')));
+  }
+  assert.match(prerequisites, /public repositories[\s\S]*CodeQL[\s\S]*free/i);
+  assert.match(
+    prerequisites,
+    /private or internal[\s\S]*GitHub Code Security[\s\S]*GitHub Advanced Security/i
+  );
+  assert.match(prerequisites, /recommend[\s\S]*`swedencentral`/i);
+  assert.match(deploymentGuide, /recommended[\s\S]*`swedencentral`/i);
+});
+```
+
+- [ ] **Step 2: Add onboarding and response-plan contract tests**
+
+Append:
+
+```javascript
+test('Cloud Agent Handover documents prescriptive SRE Agent setup', () => {
+  const scenarioRoot = resolve(repositoryRoot, 'scenarios/cloud-agent-handover');
+  const onboardingGuide = readFileSync(
+    resolve(scenarioRoot, 'docs/03-onboard-sre-agent.md'),
+    'utf8'
+  );
+
+  for (const panel of ['Code', 'Logs', 'Azure Resources', 'Incidents']) {
+    assert.match(onboardingGuide, new RegExp(`\\*\\*${panel}\\*\\*`));
+  }
+  assert.match(onboardingGuide, /Complete setup/i);
+  assert.match(onboardingGuide, /Azure Monitor/i);
+  assert.match(onboardingGuide, /`<workload>-ai`/i);
+  assert.match(onboardingGuide, /Logs[\s\S]*skip/i);
+  assert.match(onboardingGuide, /Code[\s\S]*green check/i);
+  assert.match(onboardingGuide, /Azure Resources[\s\S]*permissions complete/i);
+});
+
+test('Cloud Agent Handover documents current governed response-plan flow', () => {
+  const responsePlan = readFileSync(
+    resolve(
+      repositoryRoot,
+      'scenarios/cloud-agent-handover/docs/04-configure-incident-response.md'
+    ),
+    'utf8'
+  );
+
+  assert.match(responsePlan, /Azure Monitor[\s\S]*connected/i);
+  assert.match(responsePlan, /cloud-agent-handover-investigator/);
+  assert.match(responsePlan, /Builder[\s\S]*Agent Canvas/i);
+  assert.match(
+    responsePlan,
+    /Create[\s\S]*Trigger[\s\S]*Incident response plan/i
+  );
+  assert.match(responsePlan, /Agent autonomy level[\s\S]*Review/i);
+  assert.match(responsePlan, /one unassigned GitHub issue/i);
+});
+```
+
+- [ ] **Step 3: Run the focused tests and verify failure**
+
+Run:
+
+```bash
+npm --prefix scripts/scenario-tools test -- \
+  --test-name-pattern="Cloud Agent Handover documents"
+```
+
+Expected: the new tests fail because the existing documentation does not yet
+contain all provider, licensing, setup-panel, custom-agent, and navigation
+contracts.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add scripts/scenario-tools/test/cloud-agent-handover-setup.test.js
+git commit -m "test: cover handover workshop guidance" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+  -m "Copilot-Session: 1b3476c7-b401-4c19-82f9-7d1361f60f02"
+```
+
+### Task 2: Update Prerequisites and Region Guidance
+
+**Files:**
+- Modify: `scenarios/cloud-agent-handover/docs/00-prerequisites.md`
+- Modify: `scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md`
+- Test: `scripts/scenario-tools/test/cloud-agent-handover-setup.test.js`
+
+- [ ] **Step 1: Add Azure provider and CodeQL prerequisites**
+
+In the Access section of `00-prerequisites.md`, add:
+
+```markdown
+- Permission to register Azure resource providers in the workshop subscription
+  when they are not already registered. Setup requires:
+  `Microsoft.Web`, `Microsoft.Insights`, and
+  `Microsoft.OperationalInsights`.
+- CodeQL is available for public repositories without a GitHub Code Security
+  license. For a private or internal participant-owned repository, the
+  organization must enable GitHub Code Security, historically part of GitHub
+  Advanced Security, so the CodeQL workflow can upload results.
+```
+
+Add a provider preflight section with:
+
+```bash
+for provider in Microsoft.Web Microsoft.Insights Microsoft.OperationalInsights; do
+  az provider show --namespace "$provider" --query registrationState -o tsv
+done
+```
+
+State that `Registered` is ready and that setup registers missing providers,
+but the signed-in identity must be allowed to register them.
+
+- [ ] **Step 2: Make Sweden Central the explicit recommendation**
+
+Replace the supported-region introduction with:
+
+```markdown
+## Supported regions
+
+Use `swedencentral` for workshop deployments. It is the recommended region
+after participants encountered quota constraints in other supported regions.
+If Sweden Central is unavailable for your subscription, use one of the
+supported alternatives:
+
+- `eastus2`
+- `australiaeast`
+```
+
+Add readiness checklist entries for the CodeQL licensing rule, provider
+registration, and Sweden Central selection.
+
+- [ ] **Step 3: Lead deployment with Sweden Central**
+
+In `01-deploy-infrastructure.md`, make the first Bash and PowerShell examples:
+
+```bash
+scenarios/cloud-agent-handover/scripts/setup.sh --location swedencentral
+```
+
+```powershell
+scenarios/cloud-agent-handover/scripts/setup.ps1 -Location swedencentral
+```
+
+Retain examples for custom workload names and explicitly state that the scripts
+still support East US 2 and Australia East when Sweden Central is unavailable.
+
+- [ ] **Step 4: Run the prerequisite contract**
+
+Run:
+
+```bash
+npm --prefix scripts/scenario-tools test -- \
+  --test-name-pattern="providers, CodeQL licensing, and recommended region"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit prerequisite and region guidance**
+
+```bash
+git add \
+  scenarios/cloud-agent-handover/docs/00-prerequisites.md \
+  scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md
+git commit -m "docs: clarify handover prerequisites and region" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+  -m "Copilot-Session: 1b3476c7-b401-4c19-82f9-7d1361f60f02"
+```
+
+### Task 3: Make SRE Agent Onboarding Prescriptive
+
+**Files:**
+- Modify: `scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md`
+- Test: `scripts/scenario-tools/test/cloud-agent-handover-setup.test.js`
+
+- [ ] **Step 1: Document exact agent-resource inputs**
+
+Replace the short creation list with a section that instructs learners to use:
+
+```markdown
+| Input | Workshop value |
+| --- | --- |
+| Subscription | The subscription used by setup |
+| Resource group | `rg-<workload>` |
+| Region | The same supported region as the scenario resources; use Sweden Central for the recommended deployment |
+| Application Insights | `<workload>-ai` |
+| Model provider and model | A supported option available to the tenant in that region |
+```
+
+Explain that creating the agent resource does not grant its managed identity
+access to workload data.
+
+- [ ] **Step 2: Document Complete setup panels**
+
+Add a setup table:
+
+```markdown
+| Panel | Required action | Expected result |
+| --- | --- | --- |
+| **Code** | Connect the generated GitHub repository. | The card shows a green check and begins indexing. |
+| **Logs** | Skip additional connectors for this workshop. | Log Analytics and Application Insights remain available through the Azure Resources grant. |
+| **Azure Resources** | Add `rg-<workload>` with Reader-level access. | The card lists the resource group with permissions complete. |
+| **Incidents** | Connect Azure Monitor. | Azure Monitor is shown as the connected incident platform. |
+```
+
+State that **Quickstart** contains Code, Logs, Deployments, and Incidents;
+**Full setup** adds Azure Resources and knowledge files; and **Complete setup**
+in the status bar returns to the page.
+
+- [ ] **Step 3: Preserve operational guidance and onboarding verification**
+
+Keep the Knowledge base upload instructions, then add a final checklist:
+
+```markdown
+- [ ] **Code** shows a green check for the generated repository.
+- [ ] **Logs** has no extra connector because none is required.
+- [ ] **Azure Resources** lists `rg-<workload>` with permissions complete.
+- [ ] **Incidents** shows Azure Monitor connected.
+- [ ] `operational-guidelines.md` is Indexed.
+```
+
+Retain **Done and go to agent** and explain that Team Onboarding appears in
+Favorites.
+
+- [ ] **Step 4: Run the onboarding contract**
+
+Run:
+
+```bash
+npm --prefix scripts/scenario-tools test -- \
+  --test-name-pattern="prescriptive SRE Agent setup"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit onboarding guidance**
+
+```bash
+git add scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md
+git commit -m "docs: prescribe handover agent onboarding" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+  -m "Copilot-Session: 1b3476c7-b401-4c19-82f9-7d1361f60f02"
+```
+
+### Task 4: Correct the Incident Response Plan Flow
+
+**Files:**
+- Modify: `scenarios/cloud-agent-handover/docs/04-configure-incident-response.md`
+- Test: `scripts/scenario-tools/test/cloud-agent-handover-setup.test.js`
+
+- [ ] **Step 1: Add incident-platform verification**
+
+Before custom-agent and plan creation, add:
+
+```markdown
+## Verify the incident platform
+
+Open **Builder → Incident Platform** and confirm that **Azure Monitor** is
+connected. If it is not connected, return to **Complete setup → Quickstart →
+Incidents**, connect Azure Monitor, and then return here.
+```
+
+- [ ] **Step 2: Add the scenario custom agent**
+
+Document creation through **Builder → Agent Canvas → Create → Custom Agent**
+with:
+
+- name `cloud-agent-handover-investigator`
+- handoff description `Investigate the unfinished Cloud Agent Handover feature`
+- the indexed operational-guidelines file enabled
+- read/investigation tools for Azure resources, logs, repository source, and
+  GitHub history
+- only the GitHub issue-creation write operation required by the handoff
+
+Use these instructions:
+
+```text
+Investigate the Cloud Agent Handover incident. Correlate the alert named
+"Unfinished feature returns HTTP 500" with Application Insights and Log
+Analytics evidence, the connected Azure resources, repository source, tests,
+and GitHub history. Identify the unfinished POST /api/feature implementation.
+Never change Azure resources or repository code directly. Present the evidence
+and request explicit operator approval before creating one unassigned GitHub
+issue. The learner assigns Copilot, reviews and merges its pull request, then
+an operator deploys the reviewed main branch with the scenario-local deploy
+helper.
+```
+
+- [ ] **Step 3: Make the response-plan route explicit**
+
+Use this sequence:
+
+```markdown
+1. Open **Builder → Agent Canvas**.
+2. Select **Create**, then **Trigger → Incident response plan**.
+3. Enter `cloud-agent-handover-review`.
+4. Select `cloud-agent-handover-investigator`.
+5. Set **Severity** to **Sev2**.
+6. Set **Title contains** to `Unfinished feature returns HTTP 500`.
+7. Set **Agent autonomy level** to **Review**.
+8. Keep the default three-hour reinvestigation cooldown.
+9. Select **Next**, review the incident preview, then select **Create**.
+10. Verify the plan is **On** in the response-plan grid.
+```
+
+Retain the `quickstart` plan deletion warning and the governed issue-creation
+explanation.
+
+- [ ] **Step 4: Run the response-plan contract**
+
+Run:
+
+```bash
+npm --prefix scripts/scenario-tools test -- \
+  --test-name-pattern="current governed response-plan flow"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the incident-response guidance**
+
+```bash
+git add scenarios/cloud-agent-handover/docs/04-configure-incident-response.md
+git commit -m "docs: correct handover response plan setup" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+  -m "Copilot-Session: 1b3476c7-b401-4c19-82f9-7d1361f60f02"
+```
+
+### Task 5: Validate the Complete Change
+
+**Files:**
+- Modify if generated: `README.md`
+
+- [ ] **Step 1: Run all scenario-tool tests**
+
+Run:
+
+```bash
+npm --prefix scripts/scenario-tools test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Regenerate derived scenario artifacts**
+
+Run:
+
+```bash
+scripts/validate-scenarios.sh --write
+```
+
+Expected: validation succeeds and generated content is updated only when
+manifest-derived output changed.
+
+- [ ] **Step 3: Run clean validation**
+
+Run:
+
+```bash
+scripts/validate-scenarios.sh
+```
+
+Expected: validation succeeds with no catalog drift.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run:
+
+```bash
+git --no-pager diff HEAD~4 -- \
+  scripts/scenario-tools/test/cloud-agent-handover-setup.test.js \
+  scenarios/cloud-agent-handover/docs/00-prerequisites.md \
+  scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md \
+  scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md \
+  scenarios/cloud-agent-handover/docs/04-configure-incident-response.md \
+  README.md
+```
+
+Expected: the diff implements all requested feedback except Azure DevOps
+Boards, contains no changes under `docs/superpowers/**`, and preserves the
+governed Cloud Agent Handover recovery model.
+
+- [ ] **Step 5: Commit generated artifacts if needed**
+
+If `README.md` changed:
+
+```bash
+git add README.md
+git commit -m "docs: refresh scenario catalog" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+  -m "Copilot-Session: 1b3476c7-b401-4c19-82f9-7d1361f60f02"
+```
+
+If it did not change, do not create an empty commit.

--- a/scenarios/cloud-agent-handover/docs/00-prerequisites.md
+++ b/scenarios/cloud-agent-handover/docs/00-prerequisites.md
@@ -24,6 +24,9 @@ You need:
 - An Azure subscription with **Contributor** at the scenario resource-group
   scope or broader. The signed-in Azure CLI user performs the initial and
   recovery deployments.
+- Permission to register Azure resource providers in the workshop subscription
+  when they are not already registered. Setup requires `Microsoft.Web`,
+  `Microsoft.Insights`, and `Microsoft.OperationalInsights`.
 - When rerunning setup over an older deployment that still has the former
   GitHub deployment identity, **Owner** or **User Access Administrator** is
   required once to remove its legacy role assignment. A fresh deployment does
@@ -33,6 +36,10 @@ You need:
   repository.
 - Permission to connect that repository through the SRE Agent GitHub
   integrations.
+- For public repositories, CodeQL is available for free. For a private or internal
+  participant-owned repository, enable GitHub Code Security, historically part
+  of GitHub Advanced Security, so the
+  workshop's CodeQL workflow can upload results.
 
 ## Tools
 
@@ -73,6 +80,27 @@ the active subscription and print its name and ID before Azure operations.
 
 The GitHub scopes required by your organization may vary with its policy.
 
+### Azure resource providers
+
+Check the registration state before setup:
+
+```bash
+for provider in Microsoft.Web Microsoft.Insights Microsoft.OperationalInsights; do
+  az provider show --namespace "$provider" --query registrationState -o tsv
+done
+```
+
+```powershell
+@("Microsoft.Web", "Microsoft.Insights", "Microsoft.OperationalInsights") |
+  ForEach-Object {
+    az provider show --namespace $_ --query registrationState -o tsv
+  }
+```
+
+`Registered` is ready. Setup registers a missing provider and waits for it to
+complete, so the signed-in identity must be allowed to register providers in
+the subscription.
+
 ### Codespaces GitHub authentication
 
 In Codespaces, setup uses the authenticated `GITHUB_TOKEN` supplied to GitHub
@@ -96,10 +124,12 @@ uv --version
 
 ## Supported regions
 
-Choose one:
+Use `swedencentral` for workshop deployments. It is the recommended region
+after participants encountered quota constraints in other supported regions.
+If Sweden Central is unavailable for your subscription, use one of these
+supported alternatives:
 
 - `eastus2`
-- `swedencentral`
 - `australiaeast`
 
 ## Readiness checklist
@@ -110,8 +140,15 @@ Choose one:
 - [ ] `dotnet --version` reports 10.x.
 - [ ] `uv --version` reports a version when you plan to run local changed-line coverage.
 - [ ] Your Azure CLI identity has Contributor access to the scenario resource group.
+- [ ] `Microsoft.Web`, `Microsoft.Insights`, and
+      `Microsoft.OperationalInsights` are registered, or your identity can
+      register them.
+- [ ] You selected the recommended `swedencentral` region, or confirmed quota
+      in another supported region.
 - [ ] For an older deployment only, you can remove its legacy role assignment
       or will delete the old resource group before rerunning setup.
 - [ ] Copilot coding agent and SRE Agent access are available.
+- [ ] CodeQL is available for the repository: public, or private/internal with
+      GitHub Code Security enabled.
 
 Next: [Deploy infrastructure and the starting app](./01-deploy-infrastructure.md).

--- a/scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md
+++ b/scenarios/cloud-agent-handover/docs/01-deploy-infrastructure.md
@@ -5,13 +5,14 @@ there is no infrastructure deployment workflow to trigger.
 
 ## Bash
 
-Use the defaults (`eastus2`, workload `srelabapp`):
+Use the recommended `swedencentral` region with the default workload
+`srelabapp`:
 
 ```bash
-scenarios/cloud-agent-handover/scripts/setup.sh
+scenarios/cloud-agent-handover/scripts/setup.sh --location swedencentral
 ```
 
-Or choose supported values:
+Or choose a custom workload name:
 
 ```bash
 scenarios/cloud-agent-handover/scripts/setup.sh \
@@ -21,19 +22,23 @@ scenarios/cloud-agent-handover/scripts/setup.sh \
 
 ## PowerShell 7
 
-Use the defaults:
+Use the recommended `swedencentral` region:
 
 ```powershell
-scenarios/cloud-agent-handover/scripts/setup.ps1
+scenarios/cloud-agent-handover/scripts/setup.ps1 -Location swedencentral
 ```
 
-Or choose supported values:
+Or choose a custom workload name:
 
 ```powershell
 scenarios/cloud-agent-handover/scripts/setup.ps1 `
   -Location swedencentral `
   -Workload myhandover
 ```
+
+The scripts also support `eastus2` and `australiaeast` when Sweden Central is
+unavailable or your subscription has insufficient quota there. If you omit the
+location argument, the script retains its `eastus2` compatibility default.
 
 ## What setup does
 

--- a/scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md
+++ b/scenarios/cloud-agent-handover/docs/03-onboard-sre-agent.md
@@ -2,45 +2,58 @@
 
 Setup deploys the Azure resources and the application, but it does **not**
 deploy an SRE Agent. Create an SRE Agent manually in
-[sre.azure.com](https://sre.azure.com) before continuing:
+[sre.azure.com](https://sre.azure.com) before continuing.
 
-1. Select the subscription in which you will create the SRE Agent resource.
-   This permission lets you deploy the agent; it does not grant the agent's
-   managed identity access to the scenario resources.
-2. Create an agent for this scenario and select **Set up your agent**.
-3. On the **Azure Resources** card, add `rg-<workload>`, review the Reader
-   permissions granted to the agent's managed identity, and finish the grant.
-4. Connect monitoring and the generated repository, then select **Done and go
-   to agent**.
+## Create the agent resource
 
-Portal labels can change, so use the current setup experience rather than
-relying on an exact screen layout. You can select an existing agent only when
-it is scoped to this scenario resource group.
+1. Select **Create agent** and use these values:
 
-## Check Azure access
+   | Input | Workshop value |
+   | --- | --- |
+   | Subscription | The subscription used by setup |
+   | Resource group | `rg-<workload>` |
+   | Region | The same supported region as the scenario resources; use Sweden Central for the recommended deployment |
+   | Application Insights | `<workload>-ai` |
+   | Model provider and model | A supported option available to your tenant in that region |
 
-On the **Team Onboarding** page, confirm that `rg-<workload>` appears on the
-**Azure Resources** card with its permission status complete. The single grant
-made during setup gives the agent read access to these resources:
+2. Review the deployment, select **Create**, then open the agent and select
+   **Set up your agent**.
+
+Creating the agent resource does not grant its managed identity access to the
+scenario resources. Configure that access during setup. You can reuse an
+existing agent only when it is scoped to this scenario resource group and uses
+the scenario's monitoring resources.
+
+## Complete setup
+
+The setup page separates fast connections from the complete configuration:
+
+- **Quickstart** contains Code, Logs, Deployments, and Incidents.
+- **Full setup** adds Azure Resources and knowledge files.
+
+If you leave this page, select **Complete setup** in the status bar to return.
+Configure the scenario as follows:
+
+| Panel | Required action | Expected result |
+| --- | --- | --- |
+| **Code** | Connect the generated GitHub repository created with **Use this template**. Follow [Connect GitHub to the SRE Agent](../../../docs/connect-github-to-sre-agent.md#connect-your-code-repository). | The card shows a green check and repository indexing starts. |
+| **Logs** | Skip additional log connectors for this workshop. | Log Analytics and Application Insights remain available through the Azure Resources grant. |
+| **Azure Resources** | Add `rg-<workload>` with Reader-level access and review the requested role assignments. | The card lists the resource group with **permissions complete**. |
+| **Incidents** | Connect **Azure Monitor** as the incident platform. | Azure Monitor is shown as connected so the scenario alert can create incidents. |
+
+No separate deployment-pipeline connection is required. The repository
+connection gives the agent the workflow context used by this scenario.
+
+The Azure Resources grant gives the agent read access to:
 
 - The App Service.
 - The Log Analytics workspace.
 - The workspace-based Application Insights resource.
 - The Azure Monitor alert named `<workload>-unfinished-feature-5xx`.
 
-Use the portal's current resource and monitoring connection steps. Keep the
-agent scoped to the scenario resource group.
-
-## Connect the generated repository
-
-On the agent setup page, use the **Code** card to connect the repository you
-created with **Use this template**. This read connection lets the agent
-correlate telemetry with the application source, tests, and deployment
-workflow.
-
-Follow [Connect GitHub to the SRE Agent: Connect your code
-repository](../../../docs/connect-github-to-sre-agent.md#connect-your-code-repository)
-for the current details.
+Keep the agent scoped to `rg-<workload>`. Reader-level setup supplies the
+resource, monitoring, and Log Analytics read permissions needed for
+investigation without granting workload modification access.
 
 ## Upload operational guidance
 
@@ -58,5 +71,21 @@ Wait until the file status is **Indexed**, then confirm that the entry shows
 `operational-guidelines.md` as a file source. A temporary chat attachment does
 not persist as agent knowledge, and the Code repository connection indexes
 source code for investigation; neither replaces this Knowledge base file.
+
+## Finish and verify onboarding
+
+Select **Done and go to agent**. The portal opens **Team Onboarding** as a
+pinned thread in the **Favorites** sidebar. Tell the agent that this is a .NET
+App Service workshop workload, that Application Insights and Log Analytics
+contain its telemetry, and that remediation must follow the approved GitHub
+issue and Copilot pull-request handoff.
+
+Before continuing, confirm:
+
+- [ ] **Code** shows a green check for the generated repository.
+- [ ] **Logs** has no extra connector because none is required.
+- [ ] **Azure Resources** lists `rg-<workload>` with **permissions complete**.
+- [ ] **Incidents** shows Azure Monitor connected.
+- [ ] `operational-guidelines.md` is **Indexed**.
 
 Next: [Configure incident response](./04-configure-incident-response.md).

--- a/scenarios/cloud-agent-handover/docs/04-configure-incident-response.md
+++ b/scenarios/cloud-agent-handover/docs/04-configure-incident-response.md
@@ -80,8 +80,9 @@ enabled can route the same alert twice or to the wrong custom agent.
    **Create**. No historical matches is normal before the scenario alert fires.
 10. In the incident response plans grid, confirm that
    `cloud-agent-handover-review` is **On** and shows the **Sev2** and title
-    filters, `cloud-agent-handover-investigator`, **Review** autonomy, and a
-    three-hour reinvestigation cooldown.
+   filters, `cloud-agent-handover-investigator`, and **Review** autonomy.
+11. Open the saved plan from its plan ID link and confirm that
+   **Reinvestigation cooldown** is enabled for three hours.
 
 In **Review** mode, the agent investigates and presents its evidence before
 the learner explicitly approves creation of one unassigned GitHub issue. The

--- a/scenarios/cloud-agent-handover/docs/04-configure-incident-response.md
+++ b/scenarios/cloud-agent-handover/docs/04-configure-incident-response.md
@@ -17,31 +17,71 @@ List recent issues from <owner>/<repository> and summarize the top 3.
 
 The agent should either list issues or safely report that none exist.
 
+## Verify the incident platform
+
+Open **Builder** → **Incident Platform** and confirm that **Azure Monitor** is
+connected. If it is not connected, return to **Complete setup** →
+**Quickstart** → **Incidents**, connect Azure Monitor, and then return here.
+
+## Create the scenario custom agent
+
+Response plans route incidents to a custom agent. Create one for this capsule:
+
+1. Open **Builder** → **Agent Canvas**.
+2. Select **Create** → **Custom Agent**.
+3. Set **Name** to `cloud-agent-handover-investigator`.
+4. Set **Handoff Description** to
+   `Investigate the unfinished Cloud Agent Handover feature`.
+5. In **Instructions**, enter:
+
+   > Investigate the Cloud Agent Handover incident. Correlate the alert named
+   > "Unfinished feature returns HTTP 500" with Application Insights and Log
+   > Analytics evidence, the connected Azure resources, repository source,
+   > tests, and GitHub history. Identify the unfinished `POST /api/feature`
+   > implementation. Never change Azure resources or repository code directly.
+   > Present the evidence and request explicit operator approval before
+   > creating one unassigned GitHub issue. The learner assigns Copilot, reviews
+   > and merges its pull request, then an operator deploys the reviewed `main`
+   > branch with the scenario-local deploy helper.
+
+6. Under **Knowledge**, enable the indexed
+   `scenarios/cloud-agent-handover/knowledge/operational-guidelines.md` file.
+7. Under **Tools**, enable the read and investigation operations needed for
+   Azure resources, logs, repository source, and GitHub history. Enable only
+   the GitHub issue-creation write operation required for the approved handoff.
+   Do not enable Azure modification, pull-request creation, merge, workflow
+   dispatch, or deployment operations.
+8. Save the custom agent. Return to **Builder** → **Agent Canvas**, switch to
+   **Table view**, and confirm that `cloud-agent-handover-investigator`
+   appears.
+
 ## Create the review plan
 
-Create one response plan for this alert. Azure Monitor is the incident
-platform for this scenario.
+Create one response plan for this alert after Azure Monitor is connected and
+`cloud-agent-handover-investigator` exists.
 
 If a default `quickstart` response plan exists, open **Builder** → **Incident
 response plans**, switch to **Table view**, and delete it. Leaving that plan
 enabled can route the same alert twice or to the wrong custom agent.
 
-1. Open **Builder** → **Agent Canvas**, select **Create**, then select
-   **Trigger** → **Incident response plan**.
-2. Enter `cloud-agent-handover-review` as the plan name, then select the
-   SRE Agent configured for this scenario as the response custom agent.
-3. Set the incident filter to match only this scenario:
-   - **Severity:** **Sev2** (Severity 2).
-   - **Title contains:** `Unfinished feature returns HTTP 500`.
-4. Set **Agent autonomy level** to **Review**. Do not select **Autonomous**.
-5. Keep **Reinvestigation cooldown** enabled at its default duration of three
+1. Open **Builder** → **Agent Canvas**.
+2. Select **Create**, then **Trigger** → **Incident response plan**.
+3. Enter `cloud-agent-handover-review` as the plan name.
+4. Select `cloud-agent-handover-investigator` as the response custom agent.
+5. Set **Severity** to **Sev2** (Severity 2).
+6. Set **Title contains** to `Unfinished feature returns HTTP 500`.
+7. Set **Agent autonomy level** to **Review**. Do not select **Autonomous**,
+   which is the default for a new plan.
+8. Keep **Reinvestigation cooldown** enabled at its default duration of three
    hours. During this window, another firing of the same Azure Monitor alert
    is merged into or reopens the existing investigation thread. Workshop
    scenarios do not require a separate investigation for every firing.
-6. Preview the matching incidents, then select **Create**.
-7. In the incident response plans list, confirm that
+9. Select **Next**, review the matching-incidents preview, then select
+   **Create**. No historical matches is normal before the scenario alert fires.
+10. In the incident response plans grid, confirm that
    `cloud-agent-handover-review` is **On** and shows the **Sev2** and title
-   filters, **Review** autonomy, and a three-hour reinvestigation cooldown.
+    filters, `cloud-agent-handover-investigator`, **Review** autonomy, and a
+    three-hour reinvestigation cooldown.
 
 In **Review** mode, the agent investigates and presents its evidence before
 the learner explicitly approves creation of one unassigned GitHub issue. The

--- a/scripts/scenario-tools/test/cloud-agent-handover-setup.test.js
+++ b/scripts/scenario-tools/test/cloud-agent-handover-setup.test.js
@@ -178,3 +178,68 @@ test('Shared Cloud Agent Handover guidance uses local deployment', () => {
     assert.doesNotMatch(document, /Deploy Cloud Agent Handover Application/);
   }
 });
+
+test('Cloud Agent Handover documents providers, CodeQL licensing, and recommended region', () => {
+  const scenarioRoot = resolve(repositoryRoot, 'scenarios/cloud-agent-handover');
+  const prerequisites = readFileSync(
+    resolve(scenarioRoot, 'docs/00-prerequisites.md'),
+    'utf8'
+  );
+  const deploymentGuide = readFileSync(
+    resolve(scenarioRoot, 'docs/01-deploy-infrastructure.md'),
+    'utf8'
+  );
+
+  for (const provider of [
+    'Microsoft.Web',
+    'Microsoft.Insights',
+    'Microsoft.OperationalInsights',
+  ]) {
+    assert.match(prerequisites, new RegExp(provider.replace('.', '\\.')));
+  }
+  assert.match(prerequisites, /public repositories[\s\S]*CodeQL[\s\S]*free/i);
+  assert.match(
+    prerequisites,
+    /private or internal[\s\S]*GitHub Code Security[\s\S]*GitHub Advanced Security/i
+  );
+  assert.match(prerequisites, /recommend[\s\S]*`swedencentral`/i);
+  assert.match(deploymentGuide, /recommended[\s\S]*`swedencentral`/i);
+});
+
+test('Cloud Agent Handover documents prescriptive SRE Agent setup', () => {
+  const scenarioRoot = resolve(repositoryRoot, 'scenarios/cloud-agent-handover');
+  const onboardingGuide = readFileSync(
+    resolve(scenarioRoot, 'docs/03-onboard-sre-agent.md'),
+    'utf8'
+  );
+
+  for (const panel of ['Code', 'Logs', 'Azure Resources', 'Incidents']) {
+    assert.match(onboardingGuide, new RegExp(`\\*\\*${panel}\\*\\*`));
+  }
+  assert.match(onboardingGuide, /Complete setup/i);
+  assert.match(onboardingGuide, /Azure Monitor/i);
+  assert.match(onboardingGuide, /`<workload>-ai`/i);
+  assert.match(onboardingGuide, /Logs[\s\S]*skip/i);
+  assert.match(onboardingGuide, /Code[\s\S]*green check/i);
+  assert.match(onboardingGuide, /Azure Resources[\s\S]*permissions complete/i);
+});
+
+test('Cloud Agent Handover documents current governed response-plan flow', () => {
+  const responsePlan = readFileSync(
+    resolve(
+      repositoryRoot,
+      'scenarios/cloud-agent-handover/docs/04-configure-incident-response.md'
+    ),
+    'utf8'
+  );
+
+  assert.match(responsePlan, /Azure Monitor[\s\S]*connected/i);
+  assert.match(responsePlan, /cloud-agent-handover-investigator/);
+  assert.match(responsePlan, /Builder[\s\S]*Agent Canvas/i);
+  assert.match(
+    responsePlan,
+    /Create[\s\S]*Trigger[\s\S]*Incident response plan/i
+  );
+  assert.match(responsePlan, /Agent autonomy level[\s\S]*Review/i);
+  assert.match(responsePlan, /one unassigned GitHub issue/i);
+});


### PR DESCRIPTION
## Summary
- document required Azure resource providers, the CodeQL licensing distinction, and Sweden Central as the recommended region
- add prescriptive SRE Agent creation and Complete setup guidance for Code, Logs, Azure Resources, and Incidents
- correct the governed custom-agent and incident response plan flow, with regression contracts
- intentionally exclude Azure DevOps Boards support from this change

## Test plan
- [x] `npm --prefix scripts/scenario-tools test`
- [x] `scripts/validate-scenarios.sh --write`
- [x] `scripts/validate-scenarios.sh`