### PR TITLE
feat: automate Azure Boards handover lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ scenarios/azure-boards-copilot-handover/app/.ruff_cache/
 scenarios/azure-boards-copilot-handover/app/.mypy_cache/
 scenarios/azure-boards-copilot-handover/app/.coverage
 scenarios/azure-boards-copilot-handover/app/uv.lock
+
+# Azure Boards Copilot Handover lifecycle test scratch space
+scripts/scenario-tools/test/.tmp-lifecycle-scratch/

--- a/scenarios/azure-boards-copilot-handover/README.md
+++ b/scenarios/azure-boards-copilot-handover/README.md
@@ -10,9 +10,10 @@ events into receipts. Valid but unsupported v2 order events remain active in
 the queue and create the primary backlog signal. Invalid order events are a
 separate domain concept and are not treated as synonyms for unsupported events.
 
-This ticket intentionally includes scaffold lifecycle placeholders only. The
-Function application, incident automation, investigation assets, Azure Boards
-journey, and connected validation are delivered separately.
+This capsule's Function application and `setup`/`deploy`/`inject`/`validate`/
+`cleanup` lifecycle scripts are implemented. Investigation assets, the Azure
+Boards learner journey, and connected (live-Azure) validation are delivered
+separately.
 
 ## Cost profile
 
@@ -24,8 +25,12 @@ provisioning, and run cleanup immediately after completing the scenario.
 
 ## Flow
 
-The scaffolded lifecycle scripts are placeholders until the later lifecycle
-ticket. The infrastructure entry point is `infra/bicep/main.bicep`.
+`scripts/setup.sh`/`.ps1` provision infrastructure, deploy the starting
+application, and seed deterministic v1 control events. `scripts/deploy.sh`/
+`.ps1` ship the current checkout. `scripts/inject.sh`/`.ps1` submits the v2
+incident batch. `scripts/validate.sh`/`.ps1` proves recovery. `scripts/
+cleanup.sh`/`.ps1` deletes only the scenario resource group. The
+infrastructure entry point is `infra/bicep/main.bicep`.
 
 ## Notes
 

--- a/scenarios/azure-boards-copilot-handover/app/function_app.py
+++ b/scenarios/azure-boards-copilot-handover/app/function_app.py
@@ -13,11 +13,12 @@ from order_events.adapters.service_bus import (
     process_order_event_message,
 )
 from order_events.adapters.storage import (
+    ReceiptTableClient,
     ReceiptTableStore,
     ScenarioStateTableClient,
     ScenarioStateTableStore,
 )
-from order_events.workshop import get_workshop_status, submit_incident_batch
+from order_events.workshop import get_workshop_status, submit_control_batch, submit_incident_batch
 
 app = func.FunctionApp()
 
@@ -36,7 +37,9 @@ def _receipt_store() -> ReceiptTableStore:
     table_client = _table_service_client().get_table_client(
         os.environ["NORMALIZED_RECEIPTS_TABLE_NAME"]
     )
-    return ReceiptTableStore(table_client)
+    # azure.data.tables.TableClient supports the required methods, but its overload-rich
+    # type stubs do not structurally satisfy our narrower protocol under mypy strict mode.
+    return ReceiptTableStore(cast(ReceiptTableClient, table_client))
 
 
 def _scenario_state_store() -> ScenarioStateTableStore:
@@ -86,11 +89,21 @@ def process_order_event(message: func.ServiceBusMessage) -> None:
 @app.function_name(name="WorkshopStatus")
 @app.route(route="status", methods=["GET"], auth_level=func.AuthLevel.FUNCTION)
 def workshop_status(req: func.HttpRequest) -> func.HttpResponse:
-    status = get_workshop_status(_scenario_state_store())
+    status = get_workshop_status(
+        _scenario_state_store(),
+        _receipt_store(),
+        deployed_commit_sha=os.environ.get("DEPLOYED_COMMIT_SHA") or None,
+        deployed_at_utc=os.environ.get("DEPLOYED_AT_UTC") or None,
+    )
     return _json_response(
         {
             "incidentBatchId": status.incident_batch_id,
             "incidentBatchInjected": status.incident_batch_injected,
+            "deployedCommitSha": status.deployed_commit_sha,
+            "deployedAtUtc": status.deployed_at_utc,
+            "normalizedReceiptCount": status.normalized_receipt_count,
+            "v1ReceiptCount": status.v1_receipt_count,
+            "v2ReceiptCount": status.v2_receipt_count,
         },
         status_code=200,
     )
@@ -109,6 +122,22 @@ def submit_v2_orders(req: func.HttpRequest) -> func.HttpResponse:
     return _json_response(
         {
             "incidentBatchAlreadyInjected": submission.already_injected,
+            "eventsEnqueued": len(submission.events),
+        },
+        status_code=200 if submission.already_injected else 202,
+    )
+
+
+@app.function_name(name="SeedV1Controls")
+@app.route(route="seed-v1-controls", methods=["POST"], auth_level=func.AuthLevel.FUNCTION)
+def seed_v1_controls(req: func.HttpRequest) -> func.HttpResponse:
+    # Same Service Bus SDK send path as SubmitV2Orders, and the same claim/complete
+    # idempotency guarantee: safe to call repeatedly (e.g. from setup.sh retries).
+    submission = submit_control_batch(_scenario_state_store(), _event_sender(), claimed_at=_clock())
+
+    return _json_response(
+        {
+            "controlBatchAlreadyInjected": submission.already_injected,
             "eventsEnqueued": len(submission.events),
         },
         status_code=200 if submission.already_injected else 202,

--- a/scenarios/azure-boards-copilot-handover/app/order_events/adapters/storage.py
+++ b/scenarios/azure-boards-copilot-handover/app/order_events/adapters/storage.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Protocol
 from uuid import uuid4
@@ -8,11 +8,15 @@ from azure.core.exceptions import ResourceExistsError, ResourceModifiedError, Re
 from azure.data.tables import UpdateMode
 
 from order_events.normalizer import NormalizedReceipt
-from order_events.workshop import BatchClaim, ClaimOutcome
+from order_events.workshop import BatchClaim, ClaimOutcome, ReceiptCounts
 
 
 class ReceiptTableClient(Protocol):
     def upsert_entity(self, entity: dict[str, object], mode: UpdateMode) -> object: ...
+
+    def query_entities(
+        self, query_filter: str, *, select: Sequence[str] | None = None
+    ) -> Iterable[Mapping[str, object]]: ...
 
 
 class StoredBatchEntity(Protocol):
@@ -66,6 +70,20 @@ class ReceiptTableStore:
             },
             mode=UpdateMode.REPLACE,
         )
+
+    def count_receipts(self) -> ReceiptCounts:
+        v1_count = 0
+        v2_count = 0
+        for entity in self._table_client.query_entities(
+            "PartitionKey eq 'orders'", select=["sourceSchemaVersion"]
+        ):
+            schema_version = entity.get("sourceSchemaVersion")
+            if schema_version == "v1":
+                v1_count += 1
+            elif schema_version == "v2":
+                v2_count += 1
+
+        return ReceiptCounts(total=v1_count + v2_count, v1=v1_count, v2=v2_count)
 
 
 _INCIDENT_BATCHES_PARTITION_KEY = "incidentBatches"

--- a/scenarios/azure-boards-copilot-handover/app/order_events/batches.py
+++ b/scenarios/azure-boards-copilot-handover/app/order_events/batches.py
@@ -1,6 +1,7 @@
 from order_events.contracts import ReceiptEventV1, ReceiptEventV2
 
 INCIDENT_BATCH_ID = "schema-drift-v2-incident"
+CONTROL_BATCH_ID = "v1-control-events"
 
 
 def build_control_events_v1() -> tuple[ReceiptEventV1, ReceiptEventV1, ReceiptEventV1]:

--- a/scenarios/azure-boards-copilot-handover/app/order_events/workshop.py
+++ b/scenarios/azure-boards-copilot-handover/app/order_events/workshop.py
@@ -4,8 +4,13 @@ from datetime import datetime
 from enum import Enum
 from typing import Protocol
 
-from order_events.batches import INCIDENT_BATCH_ID, build_incident_events_v2
-from order_events.contracts import ReceiptEventV2
+from order_events.batches import (
+    CONTROL_BATCH_ID,
+    INCIDENT_BATCH_ID,
+    build_control_events_v1,
+    build_incident_events_v2,
+)
+from order_events.contracts import ReceiptEvent
 
 
 class ClaimOutcome(Enum):
@@ -46,47 +51,78 @@ class IncidentBatchStateStore(Protocol):
 
 
 class IncidentEventSender(Protocol):
-    def send_events(self, events: Sequence[ReceiptEventV2]) -> None: ...
+    def send_events(self, events: Sequence[ReceiptEvent]) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptCounts:
+    """Aggregate normalized-receipt counts backing the keyed status surface."""
+
+    total: int
+    v1: int
+    v2: int
+
+
+class ReceiptCountStore(Protocol):
+    def count_receipts(self) -> ReceiptCounts: ...
 
 
 @dataclass(frozen=True, slots=True)
 class WorkshopStatus:
     incident_batch_id: str
     incident_batch_injected: bool
+    deployed_commit_sha: str | None
+    deployed_at_utc: str | None
+    normalized_receipt_count: int
+    v1_receipt_count: int
+    v2_receipt_count: int
 
 
 @dataclass(frozen=True, slots=True)
-class IncidentBatchSubmission:
+class BatchSubmission:
     already_injected: bool
-    events: tuple[ReceiptEventV2, ...]
+    events: tuple[ReceiptEvent, ...]
 
 
-def get_workshop_status(state_store: IncidentBatchStateStore) -> WorkshopStatus:
+def get_workshop_status(
+    state_store: IncidentBatchStateStore,
+    receipt_count_store: ReceiptCountStore,
+    *,
+    deployed_commit_sha: str | None,
+    deployed_at_utc: str | None,
+) -> WorkshopStatus:
+    counts = receipt_count_store.count_receipts()
     return WorkshopStatus(
         incident_batch_id=INCIDENT_BATCH_ID,
         incident_batch_injected=state_store.is_batch_injected(INCIDENT_BATCH_ID),
+        deployed_commit_sha=deployed_commit_sha,
+        deployed_at_utc=deployed_at_utc,
+        normalized_receipt_count=counts.total,
+        v1_receipt_count=counts.v1,
+        v2_receipt_count=counts.v2,
     )
 
 
-def submit_incident_batch(
+def _submit_batch(
     state_store: IncidentBatchStateStore,
     sender: IncidentEventSender,
     *,
+    batch_id: str,
+    events: tuple[ReceiptEvent, ...],
     claimed_at: datetime,
-) -> IncidentBatchSubmission:
-    events = build_incident_events_v2()
+) -> BatchSubmission:
     claim = state_store.claim_batch(
-        batch_id=INCIDENT_BATCH_ID, event_count=len(events), claimed_at=claimed_at
+        batch_id=batch_id, event_count=len(events), claimed_at=claimed_at
     )
 
     if claim.outcome is ClaimOutcome.ALREADY_COMPLETED:
-        return IncidentBatchSubmission(already_injected=True, events=())
+        return BatchSubmission(already_injected=True, events=())
 
     if claim.outcome is ClaimOutcome.CONTESTED:
         # Another caller still owns (or already recovered) this same pending claim; do
         # not race it with a duplicate send. The batch is not yet completed, so it
         # must not be reported as injected.
-        return IncidentBatchSubmission(already_injected=False, events=())
+        return BatchSubmission(already_injected=False, events=())
 
     claim_token = claim.claim_token
     if claim_token is None:
@@ -98,9 +134,39 @@ def submit_incident_batch(
         sender.send_events(events)
     except Exception:
         # A failed send must not leave the batch permanently claimed: release it so a
-        # future submit-v2-orders retry can reclaim and resend the same incident batch.
-        state_store.release_batch_claim(INCIDENT_BATCH_ID, claim_token=claim_token)
+        # future retry can reclaim and resend the same deterministic batch.
+        state_store.release_batch_claim(batch_id, claim_token=claim_token)
         raise
 
-    state_store.mark_batch_completed(INCIDENT_BATCH_ID, completed_at=claimed_at)
-    return IncidentBatchSubmission(already_injected=False, events=events)
+    state_store.mark_batch_completed(batch_id, completed_at=claimed_at)
+    return BatchSubmission(already_injected=False, events=events)
+
+
+def submit_incident_batch(
+    state_store: IncidentBatchStateStore,
+    sender: IncidentEventSender,
+    *,
+    claimed_at: datetime,
+) -> BatchSubmission:
+    return _submit_batch(
+        state_store,
+        sender,
+        batch_id=INCIDENT_BATCH_ID,
+        events=build_incident_events_v2(),
+        claimed_at=claimed_at,
+    )
+
+
+def submit_control_batch(
+    state_store: IncidentBatchStateStore,
+    sender: IncidentEventSender,
+    *,
+    claimed_at: datetime,
+) -> BatchSubmission:
+    return _submit_batch(
+        state_store,
+        sender,
+        batch_id=CONTROL_BATCH_ID,
+        events=build_control_events_v1(),
+        claimed_at=claimed_at,
+    )

--- a/scenarios/azure-boards-copilot-handover/app/tests/test_batches.py
+++ b/scenarios/azure-boards-copilot-handover/app/tests/test_batches.py
@@ -1,8 +1,14 @@
 from order_events.batches import (
+    CONTROL_BATCH_ID,
     INCIDENT_BATCH_ID,
     build_control_events_v1,
     build_incident_events_v2,
 )
+
+
+def test_control_batch_id_is_stable_and_distinct_from_the_incident_batch() -> None:
+    assert CONTROL_BATCH_ID == "v1-control-events"
+    assert CONTROL_BATCH_ID != INCIDENT_BATCH_ID
 
 
 def test_control_batch_contains_exactly_three_v1_events_with_stable_ids() -> None:

--- a/scenarios/azure-boards-copilot-handover/app/tests/test_function_app.py
+++ b/scenarios/azure-boards-copilot-handover/app/tests/test_function_app.py
@@ -6,10 +6,15 @@ import azure.functions as func
 import pytest
 
 import function_app
-from order_events.batches import INCIDENT_BATCH_ID, build_incident_events_v2
-from order_events.contracts import ReceiptEventV2
+from order_events.batches import (
+    CONTROL_BATCH_ID,
+    INCIDENT_BATCH_ID,
+    build_control_events_v1,
+    build_incident_events_v2,
+)
+from order_events.contracts import ReceiptEvent
 from order_events.normalizer import NormalizedReceipt
-from order_events.workshop import BatchClaim, ClaimOutcome
+from order_events.workshop import BatchClaim, ClaimOutcome, ReceiptCounts
 
 
 class FakeReceiptStore:
@@ -18,6 +23,11 @@ class FakeReceiptStore:
 
     def upsert_receipt(self, receipt: NormalizedReceipt, *, processed_at: datetime) -> None:
         self.calls.append((receipt, processed_at))
+
+    def count_receipts(self) -> ReceiptCounts:
+        v1_count = sum(1 for receipt, _ in self.calls if receipt.sourceSchemaVersion == "v1")
+        v2_count = sum(1 for receipt, _ in self.calls if receipt.sourceSchemaVersion == "v2")
+        return ReceiptCounts(total=v1_count + v2_count, v1=v1_count, v2=v2_count)
 
 
 class FakeScenarioStateStore:
@@ -66,9 +76,9 @@ class FakeScenarioStateStore:
 class FakeIncidentEventSender:
     def __init__(self, *, error: Exception | None = None) -> None:
         self._error = error
-        self.send_calls: list[tuple[ReceiptEventV2, ...]] = []
+        self.send_calls: list[tuple[ReceiptEvent, ...]] = []
 
-    def send_events(self, events: Sequence[ReceiptEventV2]) -> None:
+    def send_events(self, events: Sequence[ReceiptEvent]) -> None:
         self.send_calls.append(tuple(events))
         if self._error is not None:
             raise self._error
@@ -106,6 +116,9 @@ def test_workshop_status_reports_injection_state(monkeypatch: pytest.MonkeyPatch
         "_scenario_state_store",
         lambda: FakeScenarioStateStore(already_injected=True),
     )
+    monkeypatch.setattr(function_app, "_receipt_store", lambda: FakeReceiptStore())
+    monkeypatch.delenv("DEPLOYED_COMMIT_SHA", raising=False)
+    monkeypatch.delenv("DEPLOYED_AT_UTC", raising=False)
 
     response = function_app.workshop_status(_http_request(method="GET", route="status"))
 
@@ -113,6 +126,61 @@ def test_workshop_status_reports_injection_state(monkeypatch: pytest.MonkeyPatch
     assert json.loads(response.get_body()) == {
         "incidentBatchId": INCIDENT_BATCH_ID,
         "incidentBatchInjected": True,
+        "deployedCommitSha": None,
+        "deployedAtUtc": None,
+        "normalizedReceiptCount": 0,
+        "v1ReceiptCount": 0,
+        "v2ReceiptCount": 0,
+    }
+
+
+def test_workshop_status_reports_deployment_provenance_and_receipt_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_store = FakeReceiptStore()
+    processed_at = datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC)
+    for index in range(1, 4):
+        receipt_store.upsert_receipt(
+            NormalizedReceipt(
+                sourceSchemaVersion="v1",
+                customerId=f"control-customer-{index:03d}",
+                amountMinor=100,
+                currency="USD",
+                orderId=f"control-order-{index:03d}",
+            ),
+            processed_at=processed_at,
+        )
+    for index in range(1, 21):
+        receipt_store.upsert_receipt(
+            NormalizedReceipt(
+                sourceSchemaVersion="v2",
+                customerId=f"incident-customer-{index:03d}",
+                amountMinor=10050,
+                currency="USD",
+                orderId=f"incident-order-{index:03d}",
+            ),
+            processed_at=processed_at,
+        )
+    monkeypatch.setattr(
+        function_app,
+        "_scenario_state_store",
+        lambda: FakeScenarioStateStore(already_injected=True),
+    )
+    monkeypatch.setattr(function_app, "_receipt_store", lambda: receipt_store)
+    monkeypatch.setenv("DEPLOYED_COMMIT_SHA", "a26ce2cd82b704ebd201f5990f12ce47b53b3948")
+    monkeypatch.setenv("DEPLOYED_AT_UTC", "2026-08-17T13:52:55Z")
+
+    response = function_app.workshop_status(_http_request(method="GET", route="status"))
+
+    assert response.status_code == 200
+    assert json.loads(response.get_body()) == {
+        "incidentBatchId": INCIDENT_BATCH_ID,
+        "incidentBatchInjected": True,
+        "deployedCommitSha": "a26ce2cd82b704ebd201f5990f12ce47b53b3948",
+        "deployedAtUtc": "2026-08-17T13:52:55Z",
+        "normalizedReceiptCount": 23,
+        "v1ReceiptCount": 3,
+        "v2ReceiptCount": 20,
     }
 
 
@@ -205,6 +273,9 @@ def test_submit_v2_orders_recovers_a_pending_batch_after_a_failed_completion_wri
     sender = FakeIncidentEventSender()
     monkeypatch.setattr(function_app, "_scenario_state_store", lambda: state_store)
     monkeypatch.setattr(function_app, "_event_sender", lambda: sender)
+    monkeypatch.setattr(function_app, "_receipt_store", lambda: FakeReceiptStore())
+    monkeypatch.delenv("DEPLOYED_COMMIT_SHA", raising=False)
+    monkeypatch.delenv("DEPLOYED_AT_UTC", raising=False)
     monkeypatch.setattr(
         function_app, "_clock", lambda: datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC)
     )
@@ -219,6 +290,11 @@ def test_submit_v2_orders_recovers_a_pending_batch_after_a_failed_completion_wri
     assert json.loads(status_response.get_body()) == {
         "incidentBatchId": INCIDENT_BATCH_ID,
         "incidentBatchInjected": False,
+        "deployedCommitSha": None,
+        "deployedAtUtc": None,
+        "normalizedReceiptCount": 0,
+        "v1ReceiptCount": 0,
+        "v2ReceiptCount": 0,
     }
 
     state_store.completion_error = None
@@ -250,13 +326,61 @@ def test_submit_v2_orders_recovers_a_pending_batch_after_a_failed_completion_wri
     assert sender.send_calls == [build_incident_events_v2(), build_incident_events_v2()]
 
 
+def test_seed_v1_controls_enqueues_the_control_batch_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_store = FakeScenarioStateStore()
+    sender = FakeIncidentEventSender()
+    monkeypatch.setattr(function_app, "_scenario_state_store", lambda: state_store)
+    monkeypatch.setattr(function_app, "_event_sender", lambda: sender)
+    monkeypatch.setattr(
+        function_app, "_clock", lambda: datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC)
+    )
+
+    response = function_app.seed_v1_controls(_http_request(method="POST", route="seed-v1-controls"))
+
+    assert response.status_code == 202
+    assert json.loads(response.get_body()) == {
+        "controlBatchAlreadyInjected": False,
+        "eventsEnqueued": 3,
+    }
+    assert sender.send_calls == [build_control_events_v1()]
+    assert state_store.is_batch_injected(CONTROL_BATCH_ID) is True
+
+
+def test_seed_v1_controls_is_idempotent_when_already_injected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sender = FakeIncidentEventSender()
+    monkeypatch.setattr(
+        function_app,
+        "_scenario_state_store",
+        lambda: FakeScenarioStateStore(already_injected=True),
+    )
+    monkeypatch.setattr(function_app, "_event_sender", lambda: sender)
+
+    response = function_app.seed_v1_controls(_http_request(method="POST", route="seed-v1-controls"))
+
+    assert response.status_code == 200
+    assert json.loads(response.get_body()) == {
+        "controlBatchAlreadyInjected": True,
+        "eventsEnqueued": 0,
+    }
+    assert sender.send_calls == []
+
+
 def test_function_app_registers_the_expected_keyed_functions_without_output_bindings() -> None:
     # azure-functions' FunctionApp.get_functions() accumulates function names across
     # calls and raises on a second invocation within the same process, so every
     # assertion needing the registered functions lives in this single test.
     registered = {fn.get_function_name(): fn for fn in function_app.app.get_functions()}
 
-    assert set(registered) == {"ProcessOrderEvent", "WorkshopStatus", "SubmitV2Orders"}
+    assert set(registered) == {
+        "ProcessOrderEvent",
+        "WorkshopStatus",
+        "SubmitV2Orders",
+        "SeedV1Controls",
+    }
 
     status_trigger = registered["WorkshopStatus"].get_trigger()
     assert status_trigger is not None
@@ -265,6 +389,10 @@ def test_function_app_registers_the_expected_keyed_functions_without_output_bind
     submit_trigger = registered["SubmitV2Orders"].get_trigger()
     assert submit_trigger is not None
     assert submit_trigger.auth_level.value == "function"
+
+    seed_trigger = registered["SeedV1Controls"].get_trigger()
+    assert seed_trigger is not None
+    assert seed_trigger.auth_level.value == "function"
 
     # The Python Service Bus queue output binding does not support sending a list of
     # messages per invocation, so SubmitV2Orders must send via the Service Bus SDK

--- a/scenarios/azure-boards-copilot-handover/app/tests/test_storage_adapters.py
+++ b/scenarios/azure-boards-copilot-handover/app/tests/test_storage_adapters.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 
 from azure.core import MatchConditions
@@ -7,15 +7,23 @@ from azure.data.tables import UpdateMode
 
 from order_events.adapters.storage import ReceiptTableStore, ScenarioStateTableStore
 from order_events.normalizer import NormalizedReceipt
-from order_events.workshop import BatchClaim, ClaimOutcome
+from order_events.workshop import BatchClaim, ClaimOutcome, ReceiptCounts
 
 
 class FakeReceiptTableClient:
-    def __init__(self) -> None:
+    def __init__(self, *, entities: list[dict[str, object]] | None = None) -> None:
         self.calls: list[tuple[dict[str, object], UpdateMode]] = []
+        self._entities = entities or []
+        self.query_filters: list[tuple[str, Sequence[str] | None]] = []
 
     def upsert_entity(self, entity: dict[str, object], mode: UpdateMode) -> None:
         self.calls.append((entity, mode))
+
+    def query_entities(
+        self, query_filter: str, *, select: Sequence[str] | None = None
+    ) -> list[Mapping[str, object]]:
+        self.query_filters.append((query_filter, select))
+        return list(self._entities)
 
 
 class _FakeStoredEntity(dict[str, object]):
@@ -137,6 +145,32 @@ def test_receipt_store_upserts_receipts_idempotently_for_order_rows() -> None:
             UpdateMode.REPLACE,
         )
     ]
+
+
+def test_receipt_store_counts_receipts_split_by_schema_version() -> None:
+    table_client = FakeReceiptTableClient(
+        entities=[
+            {"sourceSchemaVersion": "v1"},
+            {"sourceSchemaVersion": "v1"},
+            {"sourceSchemaVersion": "v1"},
+            *({"sourceSchemaVersion": "v2"} for _ in range(20)),
+        ]
+    )
+    store = ReceiptTableStore(table_client)
+
+    counts = store.count_receipts()
+
+    assert counts == ReceiptCounts(total=23, v1=3, v2=20)
+    query_filter, select = table_client.query_filters[0]
+    assert query_filter == "PartitionKey eq 'orders'"
+    assert select == ["sourceSchemaVersion"]
+
+
+def test_receipt_store_counts_zero_receipts_before_any_are_processed() -> None:
+    table_client = FakeReceiptTableClient(entities=[])
+    store = ReceiptTableStore(table_client)
+
+    assert store.count_receipts() == ReceiptCounts(total=0, v1=0, v2=0)
 
 
 def test_scenario_state_store_claims_an_incident_batch_once() -> None:

--- a/scenarios/azure-boards-copilot-handover/app/tests/test_workshop_surface.py
+++ b/scenarios/azure-boards-copilot-handover/app/tests/test_workshop_surface.py
@@ -3,12 +3,19 @@ from datetime import UTC, datetime
 
 import pytest
 
-from order_events.batches import INCIDENT_BATCH_ID, build_incident_events_v2
-from order_events.contracts import ReceiptEventV2
+from order_events.batches import (
+    CONTROL_BATCH_ID,
+    INCIDENT_BATCH_ID,
+    build_control_events_v1,
+    build_incident_events_v2,
+)
+from order_events.contracts import ReceiptEvent
 from order_events.workshop import (
     BatchClaim,
     ClaimOutcome,
+    ReceiptCounts,
     get_workshop_status,
+    submit_control_batch,
     submit_incident_batch,
 )
 
@@ -63,25 +70,70 @@ class FakeIncidentBatchStateStore:
 class FakeIncidentEventSender:
     def __init__(self, *, error: Exception | None = None) -> None:
         self._error = error
-        self.send_calls: list[tuple[ReceiptEventV2, ...]] = []
+        self.send_calls: list[tuple[ReceiptEvent, ...]] = []
 
-    def send_events(self, events: Sequence[ReceiptEventV2]) -> None:
+    def send_events(self, events: Sequence[ReceiptEvent]) -> None:
         self.send_calls.append(tuple(events))
         if self._error is not None:
             raise self._error
 
 
+class FakeReceiptCountStore:
+    def __init__(self, counts: ReceiptCounts) -> None:
+        self._counts = counts
+
+    def count_receipts(self) -> ReceiptCounts:
+        return self._counts
+
+
 def test_get_workshop_status_reports_the_incident_batch_id_and_injection_state() -> None:
-    status = get_workshop_status(FakeIncidentBatchStateStore(already_injected=True))
+    status = get_workshop_status(
+        FakeIncidentBatchStateStore(already_injected=True),
+        FakeReceiptCountStore(ReceiptCounts(total=0, v1=0, v2=0)),
+        deployed_commit_sha=None,
+        deployed_at_utc=None,
+    )
 
     assert status.incident_batch_id == INCIDENT_BATCH_ID
     assert status.incident_batch_injected is True
 
 
 def test_get_workshop_status_reports_not_yet_injected() -> None:
-    status = get_workshop_status(FakeIncidentBatchStateStore(already_injected=False))
+    status = get_workshop_status(
+        FakeIncidentBatchStateStore(already_injected=False),
+        FakeReceiptCountStore(ReceiptCounts(total=0, v1=0, v2=0)),
+        deployed_commit_sha=None,
+        deployed_at_utc=None,
+    )
 
     assert status.incident_batch_injected is False
+
+
+def test_get_workshop_status_reports_deployment_provenance_and_receipt_counts() -> None:
+    status = get_workshop_status(
+        FakeIncidentBatchStateStore(already_injected=True),
+        FakeReceiptCountStore(ReceiptCounts(total=23, v1=3, v2=20)),
+        deployed_commit_sha="a26ce2cd82b704ebd201f5990f12ce47b53b3948",
+        deployed_at_utc="2026-08-17T13:52:55Z",
+    )
+
+    assert status.deployed_commit_sha == "a26ce2cd82b704ebd201f5990f12ce47b53b3948"
+    assert status.deployed_at_utc == "2026-08-17T13:52:55Z"
+    assert status.normalized_receipt_count == 23
+    assert status.v1_receipt_count == 3
+    assert status.v2_receipt_count == 20
+
+
+def test_get_workshop_status_allows_unset_deployment_provenance_before_the_first_deploy() -> None:
+    status = get_workshop_status(
+        FakeIncidentBatchStateStore(),
+        FakeReceiptCountStore(ReceiptCounts(total=0, v1=0, v2=0)),
+        deployed_commit_sha=None,
+        deployed_at_utc=None,
+    )
+
+    assert status.deployed_commit_sha is None
+    assert status.deployed_at_utc is None
 
 
 def test_submit_incident_batch_claims_sends_and_completes_the_twenty_v2_events_once() -> None:
@@ -179,3 +231,42 @@ def test_submit_incident_batch_recovers_a_pending_claim_after_a_failed_completio
     assert later_submission.already_injected is True
     assert later_submission.events == ()
     assert sender.send_calls == [build_incident_events_v2(), build_incident_events_v2()]
+
+
+def test_submit_control_batch_claims_sends_and_completes_the_three_v1_events_once() -> None:
+    state_store = FakeIncidentBatchStateStore()
+    sender = FakeIncidentEventSender()
+    claimed_at = datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC)
+
+    submission = submit_control_batch(state_store, sender, claimed_at=claimed_at)
+
+    assert submission.already_injected is False
+    assert submission.events == build_control_events_v1()
+    assert state_store.claim_calls == [(CONTROL_BATCH_ID, 3, claimed_at)]
+    assert sender.send_calls == [build_control_events_v1()]
+    assert state_store.completed_calls == [(CONTROL_BATCH_ID, claimed_at)]
+    assert state_store.is_batch_injected(CONTROL_BATCH_ID) is True
+
+
+def test_submit_control_batch_is_idempotent_when_already_claimed() -> None:
+    state_store = FakeIncidentBatchStateStore(already_injected=True)
+    sender = FakeIncidentEventSender()
+    claimed_at = datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC)
+
+    submission = submit_control_batch(state_store, sender, claimed_at=claimed_at)
+
+    assert submission.already_injected is True
+    assert submission.events == ()
+    assert sender.send_calls == []
+
+
+def test_submit_control_batch_releases_the_claim_and_reraises_when_send_fails() -> None:
+    state_store = FakeIncidentBatchStateStore()
+    sender = FakeIncidentEventSender(error=RuntimeError("simulated Service Bus send failure"))
+    claimed_at = datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC)
+
+    with pytest.raises(RuntimeError, match="simulated Service Bus send failure"):
+        submit_control_batch(state_store, sender, claimed_at=claimed_at)
+
+    assert state_store.released_batches == [(CONTROL_BATCH_ID, "claim-token-1")]
+    assert state_store.is_batch_injected(CONTROL_BATCH_ID) is False

--- a/scenarios/azure-boards-copilot-handover/scripts/cleanup.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/cleanup.ps1
@@ -1,3 +1,101 @@
 #!/usr/bin/env pwsh
+# Tears down the Azure Boards Copilot Handover scenario resource group. Never
+# touches GitHub or Azure Boards state: the scenario's Copilot handover work
+# item/issue lifecycle is entirely out of scope for this script.
+
+param()
+
 $ErrorActionPreference = 'Stop'
-Write-Host "Scenario cleanup is a no-op in the template."
+$Workload = 'srelabboardshandover'
+$ResourceGroup = ''
+$ResourceGroupSet = $false
+$Yes = $false
+$DryRun = $false
+
+function Show-Usage {
+    @"
+Usage: .\cleanup.ps1 [--workload <name>] [--resource-group <name>] [--subscription-id <id>] [--yes] [--dry-run]
+
+Deletes the Azure Boards Copilot Handover scenario resource group. Does not
+touch GitHub or Azure Boards.
+
+Options:
+  -w, -Workload, --workload             Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, -ResourceGroup, --resource-group  Resource group to delete (default: <workload>-rg)
+  -s, -SubscriptionId, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -y, -Yes, --yes                       Skip the confirmation prompt
+      --dry-run                        Show the selected resource group without deleting it
+  -h, -Help, --help                    Show this help
+"@ | Write-Host
+}
+
+for ($index = 0; $index -lt $args.Count; $index++) {
+    $argument = $args[$index]
+    switch ($argument) {
+        { $_ -in '-w', '-Workload', '--workload' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $Workload = $args[$index]
+        }
+        { $_ -in '-g', '-ResourceGroup', '--resource-group' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $ResourceGroup = $args[$index]
+            $ResourceGroupSet = $true
+        }
+        { $_ -in '-s', '-SubscriptionId', '--subscription-id' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $env:AZURE_SUBSCRIPTION_ID = $args[$index]
+        }
+        { $_ -in '-y', '-Yes', '--yes' } { $Yes = $true }
+        '--dry-run' { $DryRun = $true }
+        { $_ -in '-h', '-Help', '--help' } { Show-Usage; exit 0 }
+        default { throw "Unknown option: $argument" }
+    }
+}
+
+if (-not $ResourceGroupSet) { $ResourceGroup = "$Workload-rg" }
+
+Write-Host "========================================"
+Write-Host "  Azure Boards Copilot Handover — Cleanup"
+Write-Host "========================================"
+Write-Host "Resource group: $ResourceGroup"
+Write-Host ""
+
+if ($DryRun) {
+    Write-Host "Dry run: would delete resource group '$ResourceGroup'."
+    exit 0
+}
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    throw "Required command not found: az"
+}
+
+$requestedSubscriptionId = $env:AZURE_SUBSCRIPTION_ID
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId)) { az account set --subscription $requestedSubscriptionId; if ($LASTEXITCODE -ne 0) { throw "Unable to select Azure subscription '$requestedSubscriptionId'. Run 'az login', then run: az account set --subscription `"$requestedSubscriptionId`"" } }
+$activeSubscriptionId = [string](az account show --query id --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionId)) { throw "Azure CLI is not authenticated. Run 'az login' and try again." }
+$activeSubscriptionName = [string](az account show --query name --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionName)) { throw "Unable to read the active Azure subscription name." }
+$activeSubscriptionId = $activeSubscriptionId.Trim(); $activeSubscriptionName = $activeSubscriptionName.Trim()
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId) -and $activeSubscriptionId -cne $requestedSubscriptionId) { throw "Azure subscription mismatch: requested '$requestedSubscriptionId', but active subscription is '$activeSubscriptionId'. Run: az account set --subscription `"$requestedSubscriptionId`"" }
+Write-Host "Azure subscription: $activeSubscriptionName ($activeSubscriptionId)"
+
+$rg = az group show --name $ResourceGroup 2>$null
+if (-not $rg) {
+    Write-Host "Resource group '$ResourceGroup' not found. Nothing to delete."
+    exit 0
+}
+
+if (-not $Yes) {
+    $confirm = Read-Host "Delete resource group '$ResourceGroup' and ALL resources inside? [y/N]"
+    if ($confirm -notmatch '^[Yy]$') {
+        Write-Host "Cancelled."
+        exit 0
+    }
+}
+
+Write-Host "Deleting resource group '$ResourceGroup' (async)..."
+az group delete --name $ResourceGroup --yes --no-wait
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host "  Deletion started (runs in background)."
+Write-Host "  Monitor: az group show -n $ResourceGroup"
+Write-Host "========================================"

--- a/scenarios/azure-boards-copilot-handover/scripts/cleanup.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/cleanup.sh
@@ -1,4 +1,129 @@
 #!/usr/bin/env bash
+# Tears down the Azure Boards Copilot Handover scenario resource group. Never
+# touches GitHub or Azure Boards state: the scenario's Copilot handover work
+# item/issue lifecycle is entirely out of scope for this script.
 set -euo pipefail
-echo "Scenario cleanup is a no-op in the template."
-exit 0
+
+WORKLOAD="srelabboardshandover"
+RESOURCE_GROUP=""
+AUTO_YES=false
+DRY_RUN=false
+
+usage() {
+  cat <<'EOF'
+Usage: cleanup.sh [-w|--workload <name>] [-g|--resource-group <name>] [-s|--subscription-id <id>] [-y|--yes] [--dry-run]
+
+Deletes the Azure Boards Copilot Handover scenario resource group. Does not
+touch GitHub or Azure Boards.
+
+Options:
+  -w, --workload         Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, --resource-group   Resource group to delete (default: <workload>-rg)
+  -s, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -y, --yes              Skip the confirmation prompt
+      --dry-run          Show the selected resource group without deleting it
+  -h, --help             Show this help
+EOF
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "$value" ] || [[ "$value" == -* ]]; then
+    echo "Missing value for $option." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+RESOURCE_GROUP_SET=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -w|--workload)
+      require_option_value "$1" "${2:-}"
+      WORKLOAD="$2"
+      shift 2
+      ;;
+    -g|--resource-group)
+      require_option_value "$1" "${2:-}"
+      RESOURCE_GROUP="$2"
+      RESOURCE_GROUP_SET=true
+      shift 2
+      ;;
+    -s|--subscription-id)
+      require_option_value "$1" "${2:-}"
+      export AZURE_SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    -y|--yes)
+      AUTO_YES=true
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$RESOURCE_GROUP_SET" = false ]; then
+  RESOURCE_GROUP="${WORKLOAD}-rg"
+fi
+
+echo "========================================"
+echo "  Azure Boards Copilot Handover — Cleanup"
+echo "========================================"
+echo "Resource group: $RESOURCE_GROUP"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  echo "Dry run: would delete resource group '$RESOURCE_GROUP'."
+  exit 0
+fi
+
+for required_command in az; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "Required command not found: $required_command" >&2
+    exit 1
+  fi
+done
+
+requested_subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+if [ -n "$requested_subscription_id" ] && ! az account set --subscription "$requested_subscription_id"; then echo "Unable to select Azure subscription '$requested_subscription_id'. Run 'az login', then run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+active_subscription_id=$(az account show --query id --output tsv) || { echo "Azure CLI is not authenticated. Run 'az login' and try again." >&2; exit 1; }
+active_subscription_name=$(az account show --query name --output tsv) || { echo "Unable to read the active Azure subscription name." >&2; exit 1; }
+if [ -z "$active_subscription_id" ] || [ -z "$active_subscription_name" ]; then echo "Unable to read the active Azure subscription. Run 'az login' and try again." >&2; exit 1; fi
+if [ -n "$requested_subscription_id" ] && [ "$active_subscription_id" != "$requested_subscription_id" ]; then echo "Azure subscription mismatch: requested '$requested_subscription_id', but active subscription is '$active_subscription_id'. Run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+echo "Azure subscription: $active_subscription_name ($active_subscription_id)"
+
+if ! az group show --name "$RESOURCE_GROUP" &>/dev/null; then
+  echo "Resource group '$RESOURCE_GROUP' not found. Nothing to delete."
+  exit 0
+fi
+
+if [ "$AUTO_YES" = false ]; then
+  read -rp "Delete resource group '$RESOURCE_GROUP' and ALL resources inside? [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Cancelled."
+    exit 0
+  fi
+fi
+
+echo "Deleting resource group '$RESOURCE_GROUP' (async)..."
+az group delete --name "$RESOURCE_GROUP" --yes --no-wait
+
+echo ""
+echo "========================================"
+echo "  Deletion started (runs in background)."
+echo "  Monitor: az group show -n $RESOURCE_GROUP"
+echo "========================================"

--- a/scenarios/azure-boards-copilot-handover/scripts/deploy.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/deploy.ps1
@@ -2,9 +2,12 @@
 # Deploys the current checkout of the Azure Boards Copilot Handover Function
 # app to an already-provisioned scenario resource group. Runs the app's
 # baseline quality gates first, ships a clean runtime-only zip (no venv, no
-# tests), stamps the exact deployed git commit and UTC timestamp as Function
-# app settings, and waits (bounded) for the keyed status endpoint to confirm
-# the new commit is live.
+# tests), stamps the exact deployed git commit as a Function app setting, and
+# waits (bounded) for the keyed status endpoint to confirm the new commit is
+# live before stamping the DEPLOYED_AT_UTC cutover timestamp used by
+# validate.sh/.ps1 to scope post-deployment exception checks. Re-polls
+# (bounded) after that second settings write to confirm the app is still
+# coherent (settings changes can restart the app).
 
 param()
 
@@ -158,7 +161,8 @@ try {
         if ($LASTEXITCODE -ne 0) { throw "Failed to enable remote build." }
     }
 
-    # --- Stamp the exact deployed commit and UTC timestamp ---------------------
+    # --- Stamp DEPLOYED_COMMIT_SHA only; this is needed for the go-live poll
+    # below and must be available before the cutover timestamp exists. ------
     Push-Location $RepoRoot
     try {
         $deployedCommitSha = (git rev-parse HEAD).Trim()
@@ -166,46 +170,72 @@ try {
     finally {
         Pop-Location
     }
-    $deployedAtUtc = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-    Write-Host "Stamping DEPLOYED_COMMIT_SHA=$deployedCommitSha DEPLOYED_AT_UTC=$deployedAtUtc"
-    az functionapp config appsettings set --resource-group $ResourceGroup --name $FunctionApp --settings "DEPLOYED_COMMIT_SHA=$deployedCommitSha" "DEPLOYED_AT_UTC=$deployedAtUtc" --output none
-    if ($LASTEXITCODE -ne 0) { throw "Failed to stamp deployment provenance settings." }
+    Write-Host "Stamping DEPLOYED_COMMIT_SHA=$deployedCommitSha"
+    az functionapp config appsettings set --resource-group $ResourceGroup --name $FunctionApp --settings "DEPLOYED_COMMIT_SHA=$deployedCommitSha" --output none
+    if ($LASTEXITCODE -ne 0) { throw "Failed to stamp DEPLOYED_COMMIT_SHA." }
 
     # --- Deploy the zip ---------------------------------------------------------
     Write-Host "Deploying zip package to Function app '$FunctionApp' ..."
     az functionapp deploy --resource-group $ResourceGroup --name $FunctionApp --src-path $zipPath --type zip --output none
     if ($LASTEXITCODE -ne 0) { throw "Function zip deploy failed." }
 
-    # --- Wait (bounded) for the keyed status endpoint to report the new SHA ----
     $functionHostname = [string](az functionapp show --resource-group $ResourceGroup --name $FunctionApp --query defaultHostName --output tsv).Trim()
     $functionKey = [string](az functionapp keys list --resource-group $ResourceGroup --name $FunctionApp --query "functionKeys.default" --output tsv).Trim()
     $statusUrl = "https://$functionHostname/api/status?code=$functionKey"
 
-    Write-Host "Waiting for deployment to report DEPLOYED_COMMIT_SHA=$deployedCommitSha ..."
-    $deployedShaConfirmed = $false
-    for ($attempt = 1; $attempt -le $StatusPollAttempts; $attempt++) {
-        $statusBodyFile = Join-Path $WorkDir.FullName "status-$attempt.json"
-        curl -sS -o $statusBodyFile -w '%{http_code}' $statusUrl 2>$null | Out-Null
-        $reportedSha = $null
-        if (Test-Path $statusBodyFile) {
-            $reportedSha = [string](jq -er '.deployedCommitSha // empty' $statusBodyFile 2>$null)
+    # Polls (bounded by StatusPollAttempts/StatusPollDelaySeconds) the keyed
+    # status endpoint until it reports deployedCommitSha, or throws loudly on
+    # timeout. Reused for both the initial go-live check and the post-cutover
+    # coherence recheck below so neither poll is unbounded or circular.
+    function Wait-ForDeployedSha {
+        param(
+            [Parameter(Mandatory = $true)][string]$PhaseLabel
+        )
+
+        $confirmed = $false
+        for ($attempt = 1; $attempt -le $StatusPollAttempts; $attempt++) {
+            $statusBodyFile = Join-Path $WorkDir.FullName "status-$PhaseLabel-$attempt.json"
+            curl -sS -o $statusBodyFile -w '%{http_code}' $statusUrl 2>$null | Out-Null
+            $reportedSha = $null
+            if (Test-Path $statusBodyFile) {
+                $reportedSha = [string](jq -er '.deployedCommitSha // empty' $statusBodyFile 2>$null)
+            }
+            if ($reportedSha -eq $deployedCommitSha) {
+                $confirmed = $true
+                break
+            }
+            if ($attempt -lt $StatusPollAttempts) {
+                Start-Sleep -Seconds $StatusPollDelaySeconds
+            }
         }
-        if ($reportedSha -eq $deployedCommitSha) {
-            $deployedShaConfirmed = $true
-            break
-        }
-        if ($attempt -lt $StatusPollAttempts) {
-            Start-Sleep -Seconds $StatusPollDelaySeconds
+
+        if (-not $confirmed) {
+            throw "Timed out after $StatusPollAttempts attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=$deployedCommitSha during the $PhaseLabel check."
         }
     }
 
-    if (-not $deployedShaConfirmed) {
-        throw "Timed out after $StatusPollAttempts attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=$deployedCommitSha."
-    }
+    Write-Host "Waiting for deployment to report DEPLOYED_COMMIT_SHA=$deployedCommitSha ..."
+    Wait-ForDeployedSha -PhaseLabel 'go-live'
+
+    # --- Stamp DEPLOYED_AT_UTC only now that the new SHA is proven live -------
+    # This is the cutover timestamp: exception validation must only consider
+    # telemetry after this point, once the new (fixed) code is actually
+    # serving traffic, not from when the settings/deploy calls were issued.
+    $deployedAtUtc = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    Write-Host "New commit is live. Stamping DEPLOYED_AT_UTC=$deployedAtUtc"
+    az functionapp config appsettings set --resource-group $ResourceGroup --name $FunctionApp --settings "DEPLOYED_AT_UTC=$deployedAtUtc" --output none
+    if ($LASTEXITCODE -ne 0) { throw "Failed to stamp DEPLOYED_AT_UTC." }
+
+    # --- Re-confirm (bounded) the app is coherent after the cutover restart ---
+    # Changing an app setting can restart the Function app; re-poll (bounded,
+    # not unbounded/circular) to make sure it comes back reporting the same
+    # SHA before declaring the deploy complete.
+    Write-Host "Confirming the Function app is coherent after the cutover restart ..."
+    Wait-ForDeployedSha -PhaseLabel 'cutover'
 
     Write-Host ""
     Write-Host "========================================"
-    Write-Host "  Deploy complete: $deployedCommitSha"
+    Write-Host "  Deploy complete: $deployedCommitSha (deployed at $deployedAtUtc)"
     Write-Host "========================================"
 }
 finally {

--- a/scenarios/azure-boards-copilot-handover/scripts/deploy.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/deploy.ps1
@@ -1,0 +1,215 @@
+#!/usr/bin/env pwsh
+# Deploys the current checkout of the Azure Boards Copilot Handover Function
+# app to an already-provisioned scenario resource group. Runs the app's
+# baseline quality gates first, ships a clean runtime-only zip (no venv, no
+# tests), stamps the exact deployed git commit and UTC timestamp as Function
+# app settings, and waits (bounded) for the keyed status endpoint to confirm
+# the new commit is live.
+
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = $PSScriptRoot
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir '../../..')).Path
+$AppDir = Join-Path $RepoRoot 'scenarios/azure-boards-copilot-handover/app'
+
+$Workload = 'srelabboardshandover'
+$ResourceGroup = ''
+$ResourceGroupSet = $false
+$FunctionApp = ''
+$KeepTemp = $false
+
+$StatusPollAttempts = if ($env:STATUS_POLL_ATTEMPTS) { [int]$env:STATUS_POLL_ATTEMPTS } else { 20 }
+$StatusPollDelaySeconds = if ($env:STATUS_POLL_DELAY_SECONDS) { [int]$env:STATUS_POLL_DELAY_SECONDS } else { 10 }
+
+function Show-Usage {
+    @"
+Usage: .\deploy.ps1 [--workload <name>] [--resource-group <name>] [--app-name <name>] [--subscription-id <id>] [--keep-temp] [--help]
+
+Deploys the current checkout to an already-provisioned Function app.
+
+Options:
+  -w, -Workload, --workload             Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, -ResourceGroup, --resource-group  Resource group containing the Function app (default: <workload>-rg)
+  -a, -AppName, --app-name              Function app name (default: discovered via az functionapp list)
+  -s, -SubscriptionId, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+      --keep-temp                      Keep the staged zip/temp directory instead of deleting it (debugging)
+  -h, -Help, --help                    Show this help
+"@ | Write-Host
+}
+
+for ($index = 0; $index -lt $args.Count; $index++) {
+    $argument = $args[$index]
+    switch ($argument) {
+        { $_ -in '-w', '-Workload', '--workload' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $Workload = $args[$index]
+        }
+        { $_ -in '-g', '-ResourceGroup', '--resource-group' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $ResourceGroup = $args[$index]
+            $ResourceGroupSet = $true
+        }
+        { $_ -in '-a', '-AppName', '--app-name' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $FunctionApp = $args[$index]
+        }
+        { $_ -in '-s', '-SubscriptionId', '--subscription-id' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $env:AZURE_SUBSCRIPTION_ID = $args[$index]
+        }
+        '--keep-temp' { $KeepTemp = $true }
+        { $_ -in '-h', '-Help', '--help' } { Show-Usage; exit 0 }
+        default { throw "Unknown option: $argument" }
+    }
+}
+
+if (-not $ResourceGroupSet) { $ResourceGroup = "$Workload-rg" }
+
+Write-Host "========================================"
+Write-Host "  Azure Boards Copilot Handover — Deploy"
+Write-Host "========================================"
+Write-Host "Resource group: $ResourceGroup"
+
+foreach ($requiredCommand in @('az', 'git', 'curl', 'jq')) {
+    if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $requiredCommand"
+    }
+}
+if (-not (Get-Command Compress-Archive -ErrorAction SilentlyContinue)) {
+    throw "Required command not found: Compress-Archive"
+}
+
+$requestedSubscriptionId = $env:AZURE_SUBSCRIPTION_ID
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId)) { az account set --subscription $requestedSubscriptionId; if ($LASTEXITCODE -ne 0) { throw "Unable to select Azure subscription '$requestedSubscriptionId'. Run 'az login', then run: az account set --subscription `"$requestedSubscriptionId`"" } }
+$activeSubscriptionId = [string](az account show --query id --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionId)) { throw "Azure CLI is not authenticated. Run 'az login' and try again." }
+$activeSubscriptionName = [string](az account show --query name --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionName)) { throw "Unable to read the active Azure subscription name." }
+$activeSubscriptionId = $activeSubscriptionId.Trim(); $activeSubscriptionName = $activeSubscriptionName.Trim()
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId) -and $activeSubscriptionId -cne $requestedSubscriptionId) { throw "Azure subscription mismatch: requested '$requestedSubscriptionId', but active subscription is '$activeSubscriptionId'. Run: az account set --subscription `"$requestedSubscriptionId`"" }
+Write-Host "Azure subscription: $activeSubscriptionName ($activeSubscriptionId)"
+
+if ([string]::IsNullOrWhiteSpace($FunctionApp)) {
+    $FunctionApp = [string](az functionapp list --resource-group $ResourceGroup --query "[0].name" --output tsv)
+    if ([string]::IsNullOrWhiteSpace($FunctionApp)) {
+        throw "Unable to discover a Function app in resource group '$ResourceGroup'. Pass --app-name explicitly."
+    }
+}
+Write-Host "Function app: $FunctionApp"
+
+# --- Baseline quality gates (run against the current checkout) ------------
+$venvBin = Join-Path $AppDir '.venv/bin'
+if (Test-Path $venvBin) {
+    $env:PATH = "$venvBin$([System.IO.Path]::PathSeparator)$($env:PATH)"
+}
+
+foreach ($requiredTool in @('ruff', 'mypy', 'pytest')) {
+    if (-not (Get-Command $requiredTool -ErrorAction SilentlyContinue)) {
+        throw "Required Python tool not found: $requiredTool (expected in $AppDir/.venv or on PATH)"
+    }
+}
+
+Write-Host "Running baseline quality gates from $AppDir ..."
+Push-Location $AppDir
+try {
+    ruff format --check .; if ($LASTEXITCODE -ne 0) { throw "ruff format --check failed." }
+    ruff check .; if ($LASTEXITCODE -ne 0) { throw "ruff check failed." }
+    mypy; if ($LASTEXITCODE -ne 0) { throw "mypy failed." }
+    pytest; if ($LASTEXITCODE -ne 0) { throw "pytest failed." }
+}
+finally {
+    Pop-Location
+}
+
+# --- Stage a clean runtime-only zip (no venv, no tests, no caches) ---------
+$WorkDir = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()))
+$StageDir = New-Item -ItemType Directory -Path (Join-Path $WorkDir.FullName 'stage')
+
+try {
+    Copy-Item (Join-Path $AppDir 'function_app.py') $StageDir.FullName
+    Copy-Item (Join-Path $AppDir 'host.json') $StageDir.FullName
+    Copy-Item (Join-Path $AppDir 'requirements.txt') $StageDir.FullName
+
+    Push-Location $AppDir
+    try {
+        $trackedFiles = (git ls-files -- order_events) -split "`n" | Where-Object { $_ -ne '' }
+    }
+    finally {
+        Pop-Location
+    }
+    foreach ($relativePath in $trackedFiles) {
+        $destination = Join-Path $StageDir.FullName $relativePath
+        New-Item -ItemType Directory -Path (Split-Path $destination) -Force | Out-Null
+        Copy-Item (Join-Path $AppDir $relativePath) $destination
+    }
+
+    $zipPath = Join-Path $WorkDir.FullName 'app.zip'
+    Compress-Archive -Path (Join-Path $StageDir.FullName '*') -DestinationPath $zipPath
+
+    if ($KeepTemp -and $env:DEPLOY_KEEP_TEMP_DIR_LOG) {
+        Set-Content -Path $env:DEPLOY_KEEP_TEMP_DIR_LOG -Value $WorkDir.FullName
+    }
+
+    # --- Ensure remote build is enabled (idempotent) ---------------------------
+    $currentBuildSetting = [string](az functionapp config appsettings list --resource-group $ResourceGroup --name $FunctionApp --query "[?name=='SCM_DO_BUILD_DURING_DEPLOYMENT'].value | [0]" --output tsv)
+    if ($currentBuildSetting.Trim() -ne 'true') {
+        Write-Host "Enabling remote build (SCM_DO_BUILD_DURING_DEPLOYMENT)..."
+        az functionapp config appsettings set --resource-group $ResourceGroup --name $FunctionApp --settings 'SCM_DO_BUILD_DURING_DEPLOYMENT=true' --output none
+        if ($LASTEXITCODE -ne 0) { throw "Failed to enable remote build." }
+    }
+
+    # --- Stamp the exact deployed commit and UTC timestamp ---------------------
+    Push-Location $RepoRoot
+    try {
+        $deployedCommitSha = (git rev-parse HEAD).Trim()
+    }
+    finally {
+        Pop-Location
+    }
+    $deployedAtUtc = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    Write-Host "Stamping DEPLOYED_COMMIT_SHA=$deployedCommitSha DEPLOYED_AT_UTC=$deployedAtUtc"
+    az functionapp config appsettings set --resource-group $ResourceGroup --name $FunctionApp --settings "DEPLOYED_COMMIT_SHA=$deployedCommitSha" "DEPLOYED_AT_UTC=$deployedAtUtc" --output none
+    if ($LASTEXITCODE -ne 0) { throw "Failed to stamp deployment provenance settings." }
+
+    # --- Deploy the zip ---------------------------------------------------------
+    Write-Host "Deploying zip package to Function app '$FunctionApp' ..."
+    az functionapp deploy --resource-group $ResourceGroup --name $FunctionApp --src-path $zipPath --type zip --output none
+    if ($LASTEXITCODE -ne 0) { throw "Function zip deploy failed." }
+
+    # --- Wait (bounded) for the keyed status endpoint to report the new SHA ----
+    $functionHostname = [string](az functionapp show --resource-group $ResourceGroup --name $FunctionApp --query defaultHostName --output tsv).Trim()
+    $functionKey = [string](az functionapp keys list --resource-group $ResourceGroup --name $FunctionApp --query "functionKeys.default" --output tsv).Trim()
+    $statusUrl = "https://$functionHostname/api/status?code=$functionKey"
+
+    Write-Host "Waiting for deployment to report DEPLOYED_COMMIT_SHA=$deployedCommitSha ..."
+    $deployedShaConfirmed = $false
+    for ($attempt = 1; $attempt -le $StatusPollAttempts; $attempt++) {
+        $statusBodyFile = Join-Path $WorkDir.FullName "status-$attempt.json"
+        curl -sS -o $statusBodyFile -w '%{http_code}' $statusUrl 2>$null | Out-Null
+        $reportedSha = $null
+        if (Test-Path $statusBodyFile) {
+            $reportedSha = [string](jq -er '.deployedCommitSha // empty' $statusBodyFile 2>$null)
+        }
+        if ($reportedSha -eq $deployedCommitSha) {
+            $deployedShaConfirmed = $true
+            break
+        }
+        if ($attempt -lt $StatusPollAttempts) {
+            Start-Sleep -Seconds $StatusPollDelaySeconds
+        }
+    }
+
+    if (-not $deployedShaConfirmed) {
+        throw "Timed out after $StatusPollAttempts attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=$deployedCommitSha."
+    }
+
+    Write-Host ""
+    Write-Host "========================================"
+    Write-Host "  Deploy complete: $deployedCommitSha"
+    Write-Host "========================================"
+}
+finally {
+    if (-not $KeepTemp) {
+        Remove-Item -Recurse -Force $WorkDir.FullName -ErrorAction SilentlyContinue
+    }
+}

--- a/scenarios/azure-boards-copilot-handover/scripts/deploy.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/deploy.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Deploys the current checkout of the Azure Boards Copilot Handover Function
+# app to an already-provisioned scenario resource group. Runs the app's
+# baseline quality gates first, ships a clean runtime-only zip (no venv, no
+# tests), stamps the exact deployed git commit and UTC timestamp as Function
+# app settings, and waits (bounded) for the keyed status endpoint to confirm
+# the new commit is live.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SCENARIO_RELATIVE="scenarios/azure-boards-copilot-handover"
+APP_DIR="$REPO_ROOT/$SCENARIO_RELATIVE/app"
+
+WORKLOAD="srelabboardshandover"
+RESOURCE_GROUP=""
+RESOURCE_GROUP_SET=false
+FUNCTION_APP=""
+KEEP_TEMP=false
+
+STATUS_POLL_ATTEMPTS="${STATUS_POLL_ATTEMPTS:-20}"
+STATUS_POLL_DELAY_SECONDS="${STATUS_POLL_DELAY_SECONDS:-10}"
+
+usage() {
+  cat <<'EOF'
+Usage: deploy.sh [-w|--workload <name>] [-g|--resource-group <name>] [-a|--app-name <name>] [-s|--subscription-id <id>] [--keep-temp] [-h|--help]
+
+Deploys the current checkout to an already-provisioned Function app.
+
+Options:
+  -w, --workload         Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, --resource-group   Resource group containing the Function app (default: <workload>-rg)
+  -a, --app-name         Function app name (default: discovered via az functionapp list)
+  -s, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+      --keep-temp        Keep the staged zip/temp directory instead of deleting it (debugging)
+  -h, --help             Show this help
+EOF
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "$value" ] || [[ "$value" == -* ]]; then
+    echo "Missing value for $option." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -w|--workload)
+      require_option_value "$1" "${2:-}"
+      WORKLOAD="$2"
+      shift 2
+      ;;
+    -g|--resource-group)
+      require_option_value "$1" "${2:-}"
+      RESOURCE_GROUP="$2"
+      RESOURCE_GROUP_SET=true
+      shift 2
+      ;;
+    -a|--app-name)
+      require_option_value "$1" "${2:-}"
+      FUNCTION_APP="$2"
+      shift 2
+      ;;
+    -s|--subscription-id)
+      require_option_value "$1" "${2:-}"
+      export AZURE_SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    --keep-temp)
+      KEEP_TEMP=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$RESOURCE_GROUP_SET" = false ]; then
+  RESOURCE_GROUP="${WORKLOAD}-rg"
+fi
+
+echo "========================================"
+echo "  Azure Boards Copilot Handover — Deploy"
+echo "========================================"
+echo "Resource group: $RESOURCE_GROUP"
+
+for required_command in az git zip curl jq; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "Required command not found: $required_command" >&2
+    exit 1
+  fi
+done
+
+requested_subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+if [ -n "$requested_subscription_id" ] && ! az account set --subscription "$requested_subscription_id"; then echo "Unable to select Azure subscription '$requested_subscription_id'. Run 'az login', then run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+active_subscription_id=$(az account show --query id --output tsv) || { echo "Azure CLI is not authenticated. Run 'az login' and try again." >&2; exit 1; }
+active_subscription_name=$(az account show --query name --output tsv) || { echo "Unable to read the active Azure subscription name." >&2; exit 1; }
+if [ -z "$active_subscription_id" ] || [ -z "$active_subscription_name" ]; then echo "Unable to read the active Azure subscription. Run 'az login' and try again." >&2; exit 1; fi
+if [ -n "$requested_subscription_id" ] && [ "$active_subscription_id" != "$requested_subscription_id" ]; then echo "Azure subscription mismatch: requested '$requested_subscription_id', but active subscription is '$active_subscription_id'. Run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+echo "Azure subscription: $active_subscription_name ($active_subscription_id)"
+
+if [ -z "$FUNCTION_APP" ]; then
+  FUNCTION_APP=$(az functionapp list --resource-group "$RESOURCE_GROUP" --query "[0].name" --output tsv)
+  if [ -z "$FUNCTION_APP" ]; then
+    echo "Unable to discover a Function app in resource group '$RESOURCE_GROUP'. Pass --app-name explicitly." >&2
+    exit 1
+  fi
+fi
+echo "Function app: $FUNCTION_APP"
+
+# --- Baseline quality gates (run against the current checkout) ------------
+if [ -d "$APP_DIR/.venv/bin" ]; then
+  export PATH="$APP_DIR/.venv/bin:$PATH"
+fi
+
+for required_tool in ruff mypy pytest; do
+  if ! command -v "$required_tool" >/dev/null 2>&1; then
+    echo "Required Python tool not found: $required_tool (expected in $APP_DIR/.venv or on PATH)" >&2
+    exit 1
+  fi
+done
+
+echo "Running baseline quality gates from $APP_DIR ..."
+(cd "$APP_DIR" && ruff format --check .)
+(cd "$APP_DIR" && ruff check .)
+(cd "$APP_DIR" && mypy)
+(cd "$APP_DIR" && pytest)
+
+# --- Stage a clean runtime-only zip (no venv, no tests, no caches) ---------
+WORK_DIR="$(mktemp -d)"
+
+cleanup_temp() {
+  if [ "$KEEP_TEMP" = false ]; then
+    rm -rf -- "$WORK_DIR"
+  fi
+}
+trap cleanup_temp EXIT
+
+STAGE_DIR="$WORK_DIR/stage"
+mkdir -p "$STAGE_DIR"
+cp "$APP_DIR/function_app.py" "$STAGE_DIR/"
+cp "$APP_DIR/host.json" "$STAGE_DIR/"
+cp "$APP_DIR/requirements.txt" "$STAGE_DIR/"
+while IFS= read -r -d '' relative_path; do
+  destination="$STAGE_DIR/$relative_path"
+  mkdir -p "$(dirname "$destination")"
+  cp "$APP_DIR/$relative_path" "$destination"
+done < <(cd "$APP_DIR" && git ls-files -z -- order_events)
+
+(cd "$STAGE_DIR" && zip -qr "$WORK_DIR/app.zip" .)
+
+if [ "$KEEP_TEMP" = true ] && [ -n "${DEPLOY_KEEP_TEMP_DIR_LOG:-}" ]; then
+  printf '%s\n' "$WORK_DIR" > "$DEPLOY_KEEP_TEMP_DIR_LOG"
+fi
+
+# --- Ensure remote build is enabled (idempotent) ---------------------------
+current_build_setting=$(az functionapp config appsettings list \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$FUNCTION_APP" \
+  --query "[?name=='SCM_DO_BUILD_DURING_DEPLOYMENT'].value | [0]" \
+  --output tsv)
+if [ "$current_build_setting" != "true" ]; then
+  echo "Enabling remote build (SCM_DO_BUILD_DURING_DEPLOYMENT)..."
+  az functionapp config appsettings set \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$FUNCTION_APP" \
+    --settings SCM_DO_BUILD_DURING_DEPLOYMENT=true \
+    --output none
+fi
+
+# --- Stamp the exact deployed commit and UTC timestamp ---------------------
+DEPLOYED_COMMIT_SHA="$(cd "$REPO_ROOT" && git rev-parse HEAD)"
+DEPLOYED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Stamping DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA DEPLOYED_AT_UTC=$DEPLOYED_AT_UTC"
+az functionapp config appsettings set \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$FUNCTION_APP" \
+  --settings "DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA" "DEPLOYED_AT_UTC=$DEPLOYED_AT_UTC" \
+  --output none
+
+# --- Deploy the zip ---------------------------------------------------------
+echo "Deploying zip package to Function app '$FUNCTION_APP' ..."
+az functionapp deploy \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$FUNCTION_APP" \
+  --src-path "$WORK_DIR/app.zip" \
+  --type zip \
+  --output none
+
+# --- Wait (bounded) for the keyed status endpoint to report the new SHA ----
+FUNCTION_HOSTNAME=$(az functionapp show --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query defaultHostName --output tsv)
+FUNCTION_KEY=$(az functionapp keys list --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query "functionKeys.default" --output tsv)
+STATUS_URL="https://$FUNCTION_HOSTNAME/api/status?code=$FUNCTION_KEY"
+
+echo "Waiting for deployment to report DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA ..."
+attempt=0
+deployed_sha_confirmed=false
+while [ "$attempt" -lt "$STATUS_POLL_ATTEMPTS" ]; do
+  attempt=$((attempt + 1))
+  status_body_file="$WORK_DIR/status-$attempt.json"
+  curl -sS -o "$status_body_file" -w '%{http_code}' "$STATUS_URL" >/dev/null 2>&1 || true
+  reported_sha=$(jq -er '.deployedCommitSha // empty' "$status_body_file" 2>/dev/null || true)
+  if [ "$reported_sha" = "$DEPLOYED_COMMIT_SHA" ]; then
+    deployed_sha_confirmed=true
+    break
+  fi
+  if [ "$attempt" -lt "$STATUS_POLL_ATTEMPTS" ]; then
+    sleep "$STATUS_POLL_DELAY_SECONDS"
+  fi
+done
+
+if [ "$deployed_sha_confirmed" != true ]; then
+  echo "Timed out after $STATUS_POLL_ATTEMPTS attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA." >&2
+  exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "  Deploy complete: $DEPLOYED_COMMIT_SHA"
+echo "========================================"

--- a/scenarios/azure-boards-copilot-handover/scripts/deploy.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/deploy.sh
@@ -2,9 +2,12 @@
 # Deploys the current checkout of the Azure Boards Copilot Handover Function
 # app to an already-provisioned scenario resource group. Runs the app's
 # baseline quality gates first, ships a clean runtime-only zip (no venv, no
-# tests), stamps the exact deployed git commit and UTC timestamp as Function
-# app settings, and waits (bounded) for the keyed status endpoint to confirm
-# the new commit is live.
+# tests), stamps the exact deployed git commit as a Function app setting, and
+# waits (bounded) for the keyed status endpoint to confirm the new commit is
+# live before stamping the DEPLOYED_AT_UTC cutover timestamp used by
+# validate.sh/.ps1 to scope post-deployment exception checks. Re-polls
+# (bounded) after that second settings write to confirm the app is still
+# coherent (settings changes can restart the app).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -180,14 +183,14 @@ if [ "$current_build_setting" != "true" ]; then
     --output none
 fi
 
-# --- Stamp the exact deployed commit and UTC timestamp ---------------------
+# --- Stamp DEPLOYED_COMMIT_SHA only; this is needed for the go-live poll ---
+# below and must be available before the cutover timestamp exists.
 DEPLOYED_COMMIT_SHA="$(cd "$REPO_ROOT" && git rev-parse HEAD)"
-DEPLOYED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-echo "Stamping DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA DEPLOYED_AT_UTC=$DEPLOYED_AT_UTC"
+echo "Stamping DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA"
 az functionapp config appsettings set \
   --resource-group "$RESOURCE_GROUP" \
   --name "$FUNCTION_APP" \
-  --settings "DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA" "DEPLOYED_AT_UTC=$DEPLOYED_AT_UTC" \
+  --settings "DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA" \
   --output none
 
 # --- Deploy the zip ---------------------------------------------------------
@@ -199,34 +202,64 @@ az functionapp deploy \
   --type zip \
   --output none
 
-# --- Wait (bounded) for the keyed status endpoint to report the new SHA ----
 FUNCTION_HOSTNAME=$(az functionapp show --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query defaultHostName --output tsv)
 FUNCTION_KEY=$(az functionapp keys list --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query "functionKeys.default" --output tsv)
 STATUS_URL="https://$FUNCTION_HOSTNAME/api/status?code=$FUNCTION_KEY"
 
-echo "Waiting for deployment to report DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA ..."
-attempt=0
-deployed_sha_confirmed=false
-while [ "$attempt" -lt "$STATUS_POLL_ATTEMPTS" ]; do
-  attempt=$((attempt + 1))
-  status_body_file="$WORK_DIR/status-$attempt.json"
-  curl -sS -o "$status_body_file" -w '%{http_code}' "$STATUS_URL" >/dev/null 2>&1 || true
-  reported_sha=$(jq -er '.deployedCommitSha // empty' "$status_body_file" 2>/dev/null || true)
-  if [ "$reported_sha" = "$DEPLOYED_COMMIT_SHA" ]; then
-    deployed_sha_confirmed=true
-    break
-  fi
-  if [ "$attempt" -lt "$STATUS_POLL_ATTEMPTS" ]; then
-    sleep "$STATUS_POLL_DELAY_SECONDS"
-  fi
-done
+# Polls (bounded by STATUS_POLL_ATTEMPTS/STATUS_POLL_DELAY_SECONDS) the keyed
+# status endpoint until it reports DEPLOYED_COMMIT_SHA, or exits loudly on
+# timeout. Reused for both the initial go-live check and the post-cutover
+# coherence recheck below so neither poll is unbounded or circular.
+wait_for_deployed_sha() {
+  local phase_label="$1"
+  local attempt=0
+  local confirmed=false
+  local status_body_file
+  local reported_sha
 
-if [ "$deployed_sha_confirmed" != true ]; then
-  echo "Timed out after $STATUS_POLL_ATTEMPTS attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA." >&2
-  exit 1
-fi
+  while [ "$attempt" -lt "$STATUS_POLL_ATTEMPTS" ]; do
+    attempt=$((attempt + 1))
+    status_body_file="$WORK_DIR/status-$phase_label-$attempt.json"
+    curl -sS -o "$status_body_file" -w '%{http_code}' "$STATUS_URL" >/dev/null 2>&1 || true
+    reported_sha=$(jq -er '.deployedCommitSha // empty' "$status_body_file" 2>/dev/null || true)
+    if [ "$reported_sha" = "$DEPLOYED_COMMIT_SHA" ]; then
+      confirmed=true
+      break
+    fi
+    if [ "$attempt" -lt "$STATUS_POLL_ATTEMPTS" ]; then
+      sleep "$STATUS_POLL_DELAY_SECONDS"
+    fi
+  done
+
+  if [ "$confirmed" != true ]; then
+    echo "Timed out after $STATUS_POLL_ATTEMPTS attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA during the $phase_label check." >&2
+    exit 1
+  fi
+}
+
+echo "Waiting for deployment to report DEPLOYED_COMMIT_SHA=$DEPLOYED_COMMIT_SHA ..."
+wait_for_deployed_sha "go-live"
+
+# --- Stamp DEPLOYED_AT_UTC only now that the new SHA is proven live -------
+# This is the cutover timestamp: exception validation must only consider
+# telemetry after this point, once the new (fixed) code is actually serving
+# traffic, not from when the settings/deploy calls were merely issued.
+DEPLOYED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "New commit is live. Stamping DEPLOYED_AT_UTC=$DEPLOYED_AT_UTC"
+az functionapp config appsettings set \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$FUNCTION_APP" \
+  --settings "DEPLOYED_AT_UTC=$DEPLOYED_AT_UTC" \
+  --output none
+
+# --- Re-confirm (bounded) the app is coherent after the cutover restart ----
+# Changing an app setting can restart the Function app; re-poll (bounded,
+# not unbounded/circular) to make sure it comes back reporting the same SHA
+# before declaring the deploy complete.
+echo "Confirming the Function app is coherent after the cutover restart ..."
+wait_for_deployed_sha "cutover"
 
 echo ""
 echo "========================================"
-echo "  Deploy complete: $DEPLOYED_COMMIT_SHA"
+echo "  Deploy complete: $DEPLOYED_COMMIT_SHA (deployed at $DEPLOYED_AT_UTC)"
 echo "========================================"

--- a/scenarios/azure-boards-copilot-handover/scripts/inject.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/inject.ps1
@@ -1,3 +1,110 @@
 #!/usr/bin/env pwsh
+# Injects the v2 incident batch by calling the keyed submit-v2-orders
+# endpoint. A fresh submission returns 202 (accepted); a repeat submission
+# against an already-completed incident returns 200 (idempotent, recoverable).
+# Both are success. Any other response fails loudly.
+
+param()
+
 $ErrorActionPreference = 'Stop'
-Write-Host "Scenario inject is a no-op in the template."
+
+$Workload = 'srelabboardshandover'
+$ResourceGroup = ''
+$ResourceGroupSet = $false
+$FunctionApp = ''
+
+function Show-Usage {
+    @"
+Usage: .\inject.ps1 [--workload <name>] [--resource-group <name>] [--app-name <name>] [--subscription-id <id>] [--help]
+
+Submits the v2 incident order batch to the deployed Function app.
+
+Options:
+  -w, -Workload, --workload             Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, -ResourceGroup, --resource-group  Resource group containing the Function app (default: <workload>-rg)
+  -a, -AppName, --app-name              Function app name (default: discovered via az functionapp list)
+  -s, -SubscriptionId, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -h, -Help, --help                    Show this help
+"@ | Write-Host
+}
+
+for ($index = 0; $index -lt $args.Count; $index++) {
+    $argument = $args[$index]
+    switch ($argument) {
+        { $_ -in '-w', '-Workload', '--workload' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $Workload = $args[$index]
+        }
+        { $_ -in '-g', '-ResourceGroup', '--resource-group' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $ResourceGroup = $args[$index]
+            $ResourceGroupSet = $true
+        }
+        { $_ -in '-a', '-AppName', '--app-name' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $FunctionApp = $args[$index]
+        }
+        { $_ -in '-s', '-SubscriptionId', '--subscription-id' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $env:AZURE_SUBSCRIPTION_ID = $args[$index]
+        }
+        { $_ -in '-h', '-Help', '--help' } { Show-Usage; exit 0 }
+        default { throw "Unknown option: $argument" }
+    }
+}
+
+if (-not $ResourceGroupSet) { $ResourceGroup = "$Workload-rg" }
+
+Write-Host "========================================"
+Write-Host "  Azure Boards Copilot Handover — Inject"
+Write-Host "========================================"
+Write-Host "Resource group: $ResourceGroup"
+
+foreach ($requiredCommand in @('az', 'curl', 'jq')) {
+    if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $requiredCommand"
+    }
+}
+
+$requestedSubscriptionId = $env:AZURE_SUBSCRIPTION_ID
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId)) { az account set --subscription $requestedSubscriptionId; if ($LASTEXITCODE -ne 0) { throw "Unable to select Azure subscription '$requestedSubscriptionId'. Run 'az login', then run: az account set --subscription `"$requestedSubscriptionId`"" } }
+$activeSubscriptionId = [string](az account show --query id --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionId)) { throw "Azure CLI is not authenticated. Run 'az login' and try again." }
+$activeSubscriptionName = [string](az account show --query name --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionName)) { throw "Unable to read the active Azure subscription name." }
+$activeSubscriptionId = $activeSubscriptionId.Trim(); $activeSubscriptionName = $activeSubscriptionName.Trim()
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId) -and $activeSubscriptionId -cne $requestedSubscriptionId) { throw "Azure subscription mismatch: requested '$requestedSubscriptionId', but active subscription is '$activeSubscriptionId'. Run: az account set --subscription `"$requestedSubscriptionId`"" }
+Write-Host "Azure subscription: $activeSubscriptionName ($activeSubscriptionId)"
+
+if ([string]::IsNullOrWhiteSpace($FunctionApp)) {
+    $FunctionApp = [string](az functionapp list --resource-group $ResourceGroup --query "[0].name" --output tsv)
+    if ([string]::IsNullOrWhiteSpace($FunctionApp)) {
+        throw "Unable to discover a Function app in resource group '$ResourceGroup'. Pass --app-name explicitly."
+    }
+}
+Write-Host "Function app: $FunctionApp"
+
+$functionHostname = [string](az functionapp show --resource-group $ResourceGroup --name $FunctionApp --query defaultHostName --output tsv).Trim()
+$functionKey = [string](az functionapp keys list --resource-group $ResourceGroup --name $FunctionApp --query "functionKeys.default" --output tsv).Trim()
+
+$responseFile = New-TemporaryFile
+$statusFile = New-TemporaryFile
+try {
+    Write-Host "Submitting the v2 incident order batch..."
+    $submitHttpCode = curl -sS -o $responseFile.FullName -w '%{http_code}' -X POST "https://$functionHostname/api/submit-v2-orders?code=$functionKey"
+    $submitBody = Get-Content $responseFile.FullName -Raw
+
+    if ($submitHttpCode -ne '202' -and $submitHttpCode -ne '200') {
+        throw "Unexpected submit-v2-orders response: HTTP $submitHttpCode`: $submitBody"
+    }
+    Write-Host "Submit response (HTTP $submitHttpCode): $submitBody"
+
+    curl -sS -o $statusFile.FullName -w '%{http_code}' "https://$functionHostname/api/status?code=$functionKey" | Out-Null
+
+    Write-Host ""
+    Write-Host "========================================"
+    Write-Host "  Current workshop status"
+    Write-Host "========================================"
+    Get-Content $statusFile.FullName -Raw | Write-Host
+}
+finally {
+    Remove-Item -Force $responseFile.FullName, $statusFile.FullName -ErrorAction SilentlyContinue
+}

--- a/scenarios/azure-boards-copilot-handover/scripts/inject.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/inject.sh
@@ -1,4 +1,134 @@
 #!/usr/bin/env bash
+# Injects the v2 incident batch by calling the keyed submit-v2-orders
+# endpoint. A fresh submission returns 202 (accepted); a repeat submission
+# against an already-completed incident returns 200 (idempotent, recoverable).
+# Both are success. Any other response fails loudly.
 set -euo pipefail
-echo "Scenario inject is a no-op in the template."
-exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORKLOAD="srelabboardshandover"
+RESOURCE_GROUP=""
+RESOURCE_GROUP_SET=false
+FUNCTION_APP=""
+
+usage() {
+  cat <<'EOF'
+Usage: inject.sh [-w|--workload <name>] [-g|--resource-group <name>] [-a|--app-name <name>] [-s|--subscription-id <id>] [-h|--help]
+
+Submits the v2 incident order batch to the deployed Function app.
+
+Options:
+  -w, --workload         Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, --resource-group   Resource group containing the Function app (default: <workload>-rg)
+  -a, --app-name         Function app name (default: discovered via az functionapp list)
+  -s, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -h, --help             Show this help
+EOF
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "$value" ] || [[ "$value" == -* ]]; then
+    echo "Missing value for $option." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -w|--workload)
+      require_option_value "$1" "${2:-}"
+      WORKLOAD="$2"
+      shift 2
+      ;;
+    -g|--resource-group)
+      require_option_value "$1" "${2:-}"
+      RESOURCE_GROUP="$2"
+      RESOURCE_GROUP_SET=true
+      shift 2
+      ;;
+    -a|--app-name)
+      require_option_value "$1" "${2:-}"
+      FUNCTION_APP="$2"
+      shift 2
+      ;;
+    -s|--subscription-id)
+      require_option_value "$1" "${2:-}"
+      export AZURE_SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$RESOURCE_GROUP_SET" = false ]; then
+  RESOURCE_GROUP="${WORKLOAD}-rg"
+fi
+
+echo "========================================"
+echo "  Azure Boards Copilot Handover — Inject"
+echo "========================================"
+echo "Resource group: $RESOURCE_GROUP"
+
+for required_command in az curl jq; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "Required command not found: $required_command" >&2
+    exit 1
+  fi
+done
+
+requested_subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+if [ -n "$requested_subscription_id" ] && ! az account set --subscription "$requested_subscription_id"; then echo "Unable to select Azure subscription '$requested_subscription_id'. Run 'az login', then run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+active_subscription_id=$(az account show --query id --output tsv) || { echo "Azure CLI is not authenticated. Run 'az login' and try again." >&2; exit 1; }
+active_subscription_name=$(az account show --query name --output tsv) || { echo "Unable to read the active Azure subscription name." >&2; exit 1; }
+if [ -z "$active_subscription_id" ] || [ -z "$active_subscription_name" ]; then echo "Unable to read the active Azure subscription. Run 'az login' and try again." >&2; exit 1; fi
+if [ -n "$requested_subscription_id" ] && [ "$active_subscription_id" != "$requested_subscription_id" ]; then echo "Azure subscription mismatch: requested '$requested_subscription_id', but active subscription is '$active_subscription_id'. Run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+echo "Azure subscription: $active_subscription_name ($active_subscription_id)"
+
+if [ -z "$FUNCTION_APP" ]; then
+  FUNCTION_APP=$(az functionapp list --resource-group "$RESOURCE_GROUP" --query "[0].name" --output tsv)
+  if [ -z "$FUNCTION_APP" ]; then
+    echo "Unable to discover a Function app in resource group '$RESOURCE_GROUP'. Pass --app-name explicitly." >&2
+    exit 1
+  fi
+fi
+echo "Function app: $FUNCTION_APP"
+
+FUNCTION_HOSTNAME=$(az functionapp show --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query defaultHostName --output tsv)
+FUNCTION_KEY=$(az functionapp keys list --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query "functionKeys.default" --output tsv)
+
+RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$RESPONSE_FILE"' EXIT
+
+echo "Submitting the v2 incident order batch..."
+submit_http_code=$(curl -sS -o "$RESPONSE_FILE" -w '%{http_code}' -X POST "https://$FUNCTION_HOSTNAME/api/submit-v2-orders?code=$FUNCTION_KEY")
+
+if [ "$submit_http_code" != "202" ] && [ "$submit_http_code" != "200" ]; then
+  echo "Unexpected submit-v2-orders response: HTTP $submit_http_code: $(cat "$RESPONSE_FILE")" >&2
+  exit 1
+fi
+
+echo "Submit response (HTTP $submit_http_code): $(cat "$RESPONSE_FILE")"
+
+STATUS_FILE="$(mktemp)"
+trap 'rm -f "$RESPONSE_FILE" "$STATUS_FILE"' EXIT
+curl -sS -o "$STATUS_FILE" -w '%{http_code}' "https://$FUNCTION_HOSTNAME/api/status?code=$FUNCTION_KEY" >/dev/null
+
+echo ""
+echo "========================================"
+echo "  Current workshop status"
+echo "========================================"
+cat "$STATUS_FILE"
+echo ""

--- a/scenarios/azure-boards-copilot-handover/scripts/setup.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/setup.ps1
@@ -1,3 +1,162 @@
 #!/usr/bin/env pwsh
+# Provisions the Azure Boards Copilot Handover scenario end-to-end: creates the
+# subscription-scope infrastructure, deploys the current (intentionally
+# flawed, v1-only) checkout, seeds the deterministic v1 control events, and
+# prints the keyed workshop URLs a learner needs next.
+
+param()
+
 $ErrorActionPreference = 'Stop'
-Write-Host "Scenario setup is a no-op in the template."
+
+$ScriptDir = $PSScriptRoot
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir '../../..')).Path
+$ScenarioDir = Join-Path $RepoRoot 'scenarios/azure-boards-copilot-handover'
+
+$Workload = 'srelabboardshandover'
+$ResourceGroup = ''
+$ResourceGroupSet = $false
+$Location = 'eastus2'
+
+$RetryAttempts = if ($env:RETRY_ATTEMPTS) { [int]$env:RETRY_ATTEMPTS } else { 10 }
+$RetryDelaySeconds = if ($env:RETRY_DELAY_SECONDS) { [int]$env:RETRY_DELAY_SECONDS } else { 15 }
+
+function Show-Usage {
+    @"
+Usage: .\setup.ps1 [--workload <name>] [--resource-group <name>] [--location <region>] [--subscription-id <id>] [--help]
+
+Provisions the Azure Boards Copilot Handover scenario: infrastructure,
+starting application, and the deterministic v1 control-event seed.
+
+Options:
+  -w, -Workload, --workload             Workload name: 6-24 lowercase letters/numbers/hyphens (default: srelabboardshandover)
+  -g, -ResourceGroup, --resource-group  Resource group name (default: <workload>-rg)
+  -l, -Location, --location             Azure region (default: eastus2)
+  -s, -SubscriptionId, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -h, -Help, --help                    Show this help
+"@ | Write-Host
+}
+
+for ($index = 0; $index -lt $args.Count; $index++) {
+    $argument = $args[$index]
+    switch ($argument) {
+        { $_ -in '-w', '-Workload', '--workload' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $Workload = $args[$index]
+        }
+        { $_ -in '-g', '-ResourceGroup', '--resource-group' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $ResourceGroup = $args[$index]
+            $ResourceGroupSet = $true
+        }
+        { $_ -in '-l', '-Location', '--location' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $Location = $args[$index]
+        }
+        { $_ -in '-s', '-SubscriptionId', '--subscription-id' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $env:AZURE_SUBSCRIPTION_ID = $args[$index]
+        }
+        { $_ -in '-h', '-Help', '--help' } { Show-Usage; exit 0 }
+        default { throw "Unknown option: $argument" }
+    }
+}
+
+Write-Host "========================================"
+Write-Host "  Azure Boards Copilot Handover — Setup"
+Write-Host "========================================"
+Write-Host "Workload: $Workload"
+Write-Host "Location: $Location"
+
+foreach ($requiredCommand in @('az', 'curl', 'jq')) {
+    if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $requiredCommand"
+    }
+}
+
+$requestedSubscriptionId = $env:AZURE_SUBSCRIPTION_ID
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId)) { az account set --subscription $requestedSubscriptionId; if ($LASTEXITCODE -ne 0) { throw "Unable to select Azure subscription '$requestedSubscriptionId'. Run 'az login', then run: az account set --subscription `"$requestedSubscriptionId`"" } }
+$activeSubscriptionId = [string](az account show --query id --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionId)) { throw "Azure CLI is not authenticated. Run 'az login' and try again." }
+$activeSubscriptionName = [string](az account show --query name --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionName)) { throw "Unable to read the active Azure subscription name." }
+$activeSubscriptionId = $activeSubscriptionId.Trim(); $activeSubscriptionName = $activeSubscriptionName.Trim()
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId) -and $activeSubscriptionId -cne $requestedSubscriptionId) { throw "Azure subscription mismatch: requested '$requestedSubscriptionId', but active subscription is '$activeSubscriptionId'. Run: az account set --subscription `"$requestedSubscriptionId`"" }
+Write-Host "Azure subscription: $activeSubscriptionName ($activeSubscriptionId)"
+
+Write-Host "Provisioning subscription-scope infrastructure (infra/bicep/main.bicep)..."
+$deploymentOutputs = az deployment sub create `
+    --location $Location `
+    --template-file (Join-Path $ScenarioDir 'infra/bicep/main.bicep') `
+    --parameters "location=$Location" "workloadName=$Workload" `
+    --query properties.outputs `
+    --output json
+if ($LASTEXITCODE -ne 0) { throw "Subscription-scope infrastructure deployment failed." }
+
+$discoveredResourceGroup = [string]($deploymentOutputs | jq -er '.resourceGroupName.value').Trim()
+$functionApp = [string]($deploymentOutputs | jq -er '.functionAppName.value').Trim()
+$functionHostname = [string]($deploymentOutputs | jq -er '.functionAppHostName.value').Trim()
+
+if ($ResourceGroupSet -and $ResourceGroup -ne $discoveredResourceGroup) {
+    Write-Warning "Requested resource group '$ResourceGroup' differs from the provisioned resource group '$discoveredResourceGroup'; using the provisioned one."
+}
+$ResourceGroup = $discoveredResourceGroup
+
+Write-Host "Resource group: $ResourceGroup"
+Write-Host "Function app:   $functionApp"
+
+Write-Host "Deploying the current (starting) checkout (bounded retry for Function startup/RBAC propagation)..."
+$deploySucceeded = $false
+for ($attempt = 1; $attempt -le $RetryAttempts; $attempt++) {
+    & (Join-Path $ScriptDir 'deploy.ps1') -ResourceGroup $ResourceGroup -AppName $functionApp
+    if ($LASTEXITCODE -eq 0) {
+        $deploySucceeded = $true
+        break
+    }
+    if ($attempt -lt $RetryAttempts) {
+        Write-Warning "Deploy attempt $attempt failed; retrying in ${RetryDelaySeconds}s..."
+        Start-Sleep -Seconds $RetryDelaySeconds
+    }
+}
+
+if (-not $deploySucceeded) {
+    throw "Failed after $RetryAttempts attempts: deploying the starting application (startup/RBAC propagation may still be in progress)."
+}
+
+Write-Host "Retrieving the Function host key (bounded retry for startup/RBAC propagation)..."
+$functionKey = ''
+for ($attempt = 1; $attempt -le $RetryAttempts; $attempt++) {
+    $candidateKey = [string](az functionapp keys list --resource-group $ResourceGroup --name $functionApp --query "functionKeys.default" --output tsv 2>$null)
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($candidateKey)) {
+        $functionKey = $candidateKey.Trim()
+        break
+    }
+    if ($attempt -lt $RetryAttempts) {
+        Start-Sleep -Seconds $RetryDelaySeconds
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($functionKey)) {
+    throw "Failed after $RetryAttempts attempts: unable to retrieve the Function host key (startup/RBAC propagation may still be in progress)."
+}
+
+Write-Host "Seeding the deterministic v1 control events (idempotent)..."
+$seedResponseFile = New-TemporaryFile
+try {
+    $seedHttpCode = curl -sS -o $seedResponseFile.FullName -w '%{http_code}' -X POST "https://$functionHostname/api/seed-v1-controls?code=$functionKey"
+    $seedBody = Get-Content $seedResponseFile.FullName -Raw
+    if ($seedHttpCode -ne '200' -and $seedHttpCode -ne '202') {
+        throw "Seeding v1 control events failed with HTTP $seedHttpCode`: $seedBody"
+    }
+    Write-Host "Seed response: $seedBody"
+}
+finally {
+    Remove-Item -Force $seedResponseFile.FullName -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host "  Setup complete"
+Write-Host "========================================"
+Write-Host "Status URL:            https://$functionHostname/api/status?code=<FUNCTION_KEY>"
+Write-Host "Submit v2 orders URL:  https://$functionHostname/api/submit-v2-orders?code=<FUNCTION_KEY>"
+Write-Host ""
+Write-Host "Retrieve the actual key with:"
+Write-Host "  az functionapp keys list --resource-group $ResourceGroup --name $functionApp --query functionKeys.default --output tsv"

--- a/scenarios/azure-boards-copilot-handover/scripts/setup.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/setup.ps1
@@ -104,20 +104,24 @@ Write-Host "Function app:   $functionApp"
 
 Write-Host "Deploying the current (starting) checkout (bounded retry for Function startup/RBAC propagation)..."
 $deploySucceeded = $false
+$lastDeployErrorMessage = ''
 for ($attempt = 1; $attempt -le $RetryAttempts; $attempt++) {
-    & (Join-Path $ScriptDir 'deploy.ps1') -ResourceGroup $ResourceGroup -AppName $functionApp
-    if ($LASTEXITCODE -eq 0) {
+    try {
+        & (Join-Path $ScriptDir 'deploy.ps1') -ResourceGroup $ResourceGroup -AppName $functionApp
         $deploySucceeded = $true
         break
     }
-    if ($attempt -lt $RetryAttempts) {
-        Write-Warning "Deploy attempt $attempt failed; retrying in ${RetryDelaySeconds}s..."
-        Start-Sleep -Seconds $RetryDelaySeconds
+    catch {
+        $lastDeployErrorMessage = if ($_.Exception.Message) { $_.Exception.Message } else { $_.ToString() }
+        if ($attempt -lt $RetryAttempts) {
+            Write-Warning "Deploy attempt $attempt failed; retrying in ${RetryDelaySeconds}s. Last error: $lastDeployErrorMessage"
+            Start-Sleep -Seconds $RetryDelaySeconds
+        }
     }
 }
 
 if (-not $deploySucceeded) {
-    throw "Failed after $RetryAttempts attempts: deploying the starting application (startup/RBAC propagation may still be in progress)."
+    throw "Failed after $RetryAttempts attempts: deploying the starting application (startup/RBAC propagation may still be in progress). Last error: $lastDeployErrorMessage"
 }
 
 Write-Host "Retrieving the Function host key (bounded retry for startup/RBAC propagation)..."

--- a/scenarios/azure-boards-copilot-handover/scripts/setup.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/setup.sh
@@ -1,4 +1,181 @@
 #!/usr/bin/env bash
+# Provisions the Azure Boards Copilot Handover scenario end-to-end: creates the
+# subscription-scope infrastructure, deploys the current (intentionally
+# flawed, v1-only) checkout, seeds the deterministic v1 control events, and
+# prints the keyed workshop URLs a learner needs next.
 set -euo pipefail
-echo "Scenario setup is a no-op in the template."
-exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SCENARIO_RELATIVE="scenarios/azure-boards-copilot-handover"
+SCENARIO_DIR="$REPO_ROOT/$SCENARIO_RELATIVE"
+
+WORKLOAD="srelabboardshandover"
+RESOURCE_GROUP=""
+RESOURCE_GROUP_SET=false
+LOCATION="eastus2"
+
+RETRY_ATTEMPTS="${RETRY_ATTEMPTS:-10}"
+RETRY_DELAY_SECONDS="${RETRY_DELAY_SECONDS:-15}"
+
+usage() {
+  cat <<'EOF'
+Usage: setup.sh [-w|--workload <name>] [-g|--resource-group <name>] [-l|--location <region>] [-s|--subscription-id <id>] [-h|--help]
+
+Provisions the Azure Boards Copilot Handover scenario: infrastructure,
+starting application, and the deterministic v1 control-event seed.
+
+Options:
+  -w, --workload         Workload name: 6-24 lowercase letters/numbers/hyphens (default: srelabboardshandover)
+  -g, --resource-group   Resource group name (default: <workload>-rg)
+  -l, --location         Azure region (default: eastus2)
+  -s, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -h, --help             Show this help
+EOF
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "$value" ] || [[ "$value" == -* ]]; then
+    echo "Missing value for $option." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -w|--workload)
+      require_option_value "$1" "${2:-}"
+      WORKLOAD="$2"
+      shift 2
+      ;;
+    -g|--resource-group)
+      require_option_value "$1" "${2:-}"
+      RESOURCE_GROUP="$2"
+      RESOURCE_GROUP_SET=true
+      shift 2
+      ;;
+    -l|--location)
+      require_option_value "$1" "${2:-}"
+      LOCATION="$2"
+      shift 2
+      ;;
+    -s|--subscription-id)
+      require_option_value "$1" "${2:-}"
+      export AZURE_SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+echo "========================================"
+echo "  Azure Boards Copilot Handover — Setup"
+echo "========================================"
+echo "Workload: $WORKLOAD"
+echo "Location: $LOCATION"
+
+for required_command in az curl jq; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "Required command not found: $required_command" >&2
+    exit 1
+  fi
+done
+
+requested_subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+if [ -n "$requested_subscription_id" ] && ! az account set --subscription "$requested_subscription_id"; then echo "Unable to select Azure subscription '$requested_subscription_id'. Run 'az login', then run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+active_subscription_id=$(az account show --query id --output tsv) || { echo "Azure CLI is not authenticated. Run 'az login' and try again." >&2; exit 1; }
+active_subscription_name=$(az account show --query name --output tsv) || { echo "Unable to read the active Azure subscription name." >&2; exit 1; }
+if [ -z "$active_subscription_id" ] || [ -z "$active_subscription_name" ]; then echo "Unable to read the active Azure subscription. Run 'az login' and try again." >&2; exit 1; fi
+if [ -n "$requested_subscription_id" ] && [ "$active_subscription_id" != "$requested_subscription_id" ]; then echo "Azure subscription mismatch: requested '$requested_subscription_id', but active subscription is '$active_subscription_id'. Run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+echo "Azure subscription: $active_subscription_name ($active_subscription_id)"
+
+echo "Provisioning subscription-scope infrastructure (infra/bicep/main.bicep)..."
+DEPLOYMENT_OUTPUTS=$(az deployment sub create \
+  --location "$LOCATION" \
+  --template-file "$SCENARIO_DIR/infra/bicep/main.bicep" \
+  --parameters location="$LOCATION" workloadName="$WORKLOAD" \
+  --query properties.outputs \
+  --output json)
+
+DISCOVERED_RESOURCE_GROUP=$(jq -er '.resourceGroupName.value' <<<"$DEPLOYMENT_OUTPUTS")
+FUNCTION_APP=$(jq -er '.functionAppName.value' <<<"$DEPLOYMENT_OUTPUTS")
+FUNCTION_HOSTNAME=$(jq -er '.functionAppHostName.value' <<<"$DEPLOYMENT_OUTPUTS")
+
+if [ "$RESOURCE_GROUP_SET" = true ] && [ "$RESOURCE_GROUP" != "$DISCOVERED_RESOURCE_GROUP" ]; then
+  echo "Warning: requested resource group '$RESOURCE_GROUP' differs from the provisioned resource group '$DISCOVERED_RESOURCE_GROUP'; using the provisioned one." >&2
+fi
+RESOURCE_GROUP="$DISCOVERED_RESOURCE_GROUP"
+
+echo "Resource group: $RESOURCE_GROUP"
+echo "Function app:   $FUNCTION_APP"
+
+echo "Deploying the current (starting) checkout (bounded retry for Function startup/RBAC propagation)..."
+attempt=0
+deploy_succeeded=false
+while [ "$attempt" -lt "$RETRY_ATTEMPTS" ]; do
+  attempt=$((attempt + 1))
+  if "$SCRIPT_DIR/deploy.sh" --resource-group "$RESOURCE_GROUP" --app-name "$FUNCTION_APP"; then
+    deploy_succeeded=true
+    break
+  fi
+  if [ "$attempt" -lt "$RETRY_ATTEMPTS" ]; then
+    echo "Deploy attempt $attempt failed; retrying in ${RETRY_DELAY_SECONDS}s..." >&2
+    sleep "$RETRY_DELAY_SECONDS"
+  fi
+done
+
+if [ "$deploy_succeeded" != true ]; then
+  echo "Failed after $RETRY_ATTEMPTS attempts: deploying the starting application (startup/RBAC propagation may still be in progress)." >&2
+  exit 1
+fi
+
+echo "Retrieving the Function host key (bounded retry for startup/RBAC propagation)..."
+attempt=0
+FUNCTION_KEY=""
+while [ "$attempt" -lt "$RETRY_ATTEMPTS" ]; do
+  attempt=$((attempt + 1))
+  if candidate_key=$(az functionapp keys list --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query "functionKeys.default" --output tsv 2>/dev/null) && [ -n "$candidate_key" ]; then
+    FUNCTION_KEY="$candidate_key"
+    break
+  fi
+  if [ "$attempt" -lt "$RETRY_ATTEMPTS" ]; then
+    sleep "$RETRY_DELAY_SECONDS"
+  fi
+done
+
+if [ -z "$FUNCTION_KEY" ]; then
+  echo "Failed after $RETRY_ATTEMPTS attempts: unable to retrieve the Function host key (startup/RBAC propagation may still be in progress)." >&2
+  exit 1
+fi
+
+echo "Seeding the deterministic v1 control events (idempotent)..."
+SEED_RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$SEED_RESPONSE_FILE"' EXIT
+seed_http_code=$(curl -sS -o "$SEED_RESPONSE_FILE" -w '%{http_code}' -X POST "https://$FUNCTION_HOSTNAME/api/seed-v1-controls?code=$FUNCTION_KEY")
+if [ "$seed_http_code" != "200" ] && [ "$seed_http_code" != "202" ]; then
+  echo "Seeding v1 control events failed with HTTP $seed_http_code: $(cat "$SEED_RESPONSE_FILE")" >&2
+  exit 1
+fi
+echo "Seed response: $(cat "$SEED_RESPONSE_FILE")"
+
+echo ""
+echo "========================================"
+echo "  Setup complete"
+echo "========================================"
+echo "Status URL:            https://$FUNCTION_HOSTNAME/api/status?code=<FUNCTION_KEY>"
+echo "Submit v2 orders URL:  https://$FUNCTION_HOSTNAME/api/submit-v2-orders?code=<FUNCTION_KEY>"
+echo ""
+echo "Retrieve the actual key with:"
+echo "  az functionapp keys list --resource-group $RESOURCE_GROUP --name $FUNCTION_APP --query functionKeys.default --output tsv"

--- a/scenarios/azure-boards-copilot-handover/scripts/validate.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/validate.ps1
@@ -1,3 +1,193 @@
 #!/usr/bin/env pwsh
+# Proves the Azure Boards Copilot Handover incident has been fully recovered:
+# the deployed commit matches local HEAD, the incident batch is completed,
+# receipts split exactly 3 v1 / 20 v2 (23 total), the Service Bus queue has
+# zero active and zero dead-lettered messages, and no
+# UnsupportedReceiptSchemaError exceptions occurred after the deployment
+# timestamp. Query failures fail validation; nothing here repairs the app.
+
+param()
+
 $ErrorActionPreference = 'Stop'
-Write-Host "Scenario validate is a no-op in the template."
+
+$ScriptDir = $PSScriptRoot
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir '../../..')).Path
+
+$Workload = 'srelabboardshandover'
+$ResourceGroup = ''
+$ResourceGroupSet = $false
+$FunctionApp = ''
+
+function Show-Usage {
+    @"
+Usage: .\validate.ps1 [--workload <name>] [--resource-group <name>] [--app-name <name>] [--subscription-id <id>] [--help]
+
+Proves the incident is fully recovered: deployed SHA matches local HEAD, the
+incident is completed, receipts split exactly 3 v1 / 20 v2, the Service Bus
+queue is empty (zero active, zero dead-lettered), and no
+UnsupportedReceiptSchemaError exceptions occurred after deployment.
+
+Options:
+  -w, -Workload, --workload             Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, -ResourceGroup, --resource-group  Resource group containing the Function app (default: <workload>-rg)
+  -a, -AppName, --app-name              Function app name (default: discovered via az functionapp list)
+  -s, -SubscriptionId, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -h, -Help, --help                    Show this help
+"@ | Write-Host
+}
+
+for ($index = 0; $index -lt $args.Count; $index++) {
+    $argument = $args[$index]
+    switch ($argument) {
+        { $_ -in '-w', '-Workload', '--workload' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $Workload = $args[$index]
+        }
+        { $_ -in '-g', '-ResourceGroup', '--resource-group' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $ResourceGroup = $args[$index]
+            $ResourceGroupSet = $true
+        }
+        { $_ -in '-a', '-AppName', '--app-name' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $FunctionApp = $args[$index]
+        }
+        { $_ -in '-s', '-SubscriptionId', '--subscription-id' } {
+            if (++$index -ge $args.Count -or $args[$index] -like '-*') { throw "Missing value for $argument." }
+            $env:AZURE_SUBSCRIPTION_ID = $args[$index]
+        }
+        { $_ -in '-h', '-Help', '--help' } { Show-Usage; exit 0 }
+        default { throw "Unknown option: $argument" }
+    }
+}
+
+if (-not $ResourceGroupSet) { $ResourceGroup = "$Workload-rg" }
+
+Write-Host "========================================"
+Write-Host "  Azure Boards Copilot Handover — Validate"
+Write-Host "========================================"
+Write-Host "Resource group: $ResourceGroup"
+
+foreach ($requiredCommand in @('az', 'curl', 'jq', 'git')) {
+    if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $requiredCommand"
+    }
+}
+
+$requestedSubscriptionId = $env:AZURE_SUBSCRIPTION_ID
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId)) { az account set --subscription $requestedSubscriptionId; if ($LASTEXITCODE -ne 0) { throw "Unable to select Azure subscription '$requestedSubscriptionId'. Run 'az login', then run: az account set --subscription `"$requestedSubscriptionId`"" } }
+$activeSubscriptionId = [string](az account show --query id --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionId)) { throw "Azure CLI is not authenticated. Run 'az login' and try again." }
+$activeSubscriptionName = [string](az account show --query name --output tsv); if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($activeSubscriptionName)) { throw "Unable to read the active Azure subscription name." }
+$activeSubscriptionId = $activeSubscriptionId.Trim(); $activeSubscriptionName = $activeSubscriptionName.Trim()
+if (-not [string]::IsNullOrWhiteSpace($requestedSubscriptionId) -and $activeSubscriptionId -cne $requestedSubscriptionId) { throw "Azure subscription mismatch: requested '$requestedSubscriptionId', but active subscription is '$activeSubscriptionId'. Run: az account set --subscription `"$requestedSubscriptionId`"" }
+Write-Host "Azure subscription: $activeSubscriptionName ($activeSubscriptionId)"
+
+if ([string]::IsNullOrWhiteSpace($FunctionApp)) {
+    $FunctionApp = [string](az functionapp list --resource-group $ResourceGroup --query "[0].name" --output tsv)
+    if ([string]::IsNullOrWhiteSpace($FunctionApp)) {
+        throw "Unable to discover a Function app in resource group '$ResourceGroup'. Pass --app-name explicitly."
+    }
+}
+Write-Host "Function app: $FunctionApp"
+
+Push-Location $RepoRoot
+try {
+    $localHeadSha = (git rev-parse HEAD).Trim()
+}
+finally {
+    Pop-Location
+}
+
+$functionHostname = [string](az functionapp show --resource-group $ResourceGroup --name $FunctionApp --query defaultHostName --output tsv).Trim()
+$functionKey = [string](az functionapp keys list --resource-group $ResourceGroup --name $FunctionApp --query "functionKeys.default" --output tsv).Trim()
+
+$statusFile = New-TemporaryFile
+try {
+    curl -sS -o $statusFile.FullName -w '%{http_code}' "https://$functionHostname/api/status?code=$functionKey" | Out-Null
+
+    $deployedCommitSha = [string](jq -er '.deployedCommitSha // empty' $statusFile.FullName).Trim()
+    $deployedAtUtc = [string](jq -er '.deployedAtUtc // empty' $statusFile.FullName).Trim()
+    $incidentBatchInjected = [string](jq -er '.incidentBatchInjected' $statusFile.FullName).Trim()
+    $normalizedReceiptCount = [string](jq -er '.normalizedReceiptCount' $statusFile.FullName).Trim()
+    $v1ReceiptCount = [string](jq -er '.v1ReceiptCount' $statusFile.FullName).Trim()
+    $v2ReceiptCount = [string](jq -er '.v2ReceiptCount' $statusFile.FullName).Trim()
+
+    Write-Host ""
+    Write-Host "Deployed commit SHA: $deployedCommitSha"
+    Write-Host "Local HEAD SHA:      $localHeadSha"
+
+    $failures = 0
+
+    if ($deployedCommitSha -ne $localHeadSha) {
+        Write-Error "FAIL: deployed sha '$deployedCommitSha' does not match local HEAD sha '$localHeadSha'."
+        $failures++
+    }
+
+    if ($incidentBatchInjected -ne 'true') {
+        Write-Error "FAIL: the incident batch has not completed (incidentBatchInjected=$incidentBatchInjected)."
+        $failures++
+    }
+
+    if ($normalizedReceiptCount -ne '23' -or $v1ReceiptCount -ne '3' -or $v2ReceiptCount -ne '20') {
+        Write-Error "FAIL: receipt split is not exactly 3 v1 / 20 v2 (23 total); got v1=$v1ReceiptCount v2=$v2ReceiptCount total=$normalizedReceiptCount."
+        $failures++
+    }
+
+    if ($failures -ne 0) {
+        throw "Validation failed ($failures issue(s)) before querying Azure telemetry."
+    }
+
+    Write-Host "Receipts: $normalizedReceiptCount total ($v1ReceiptCount v1 / $v2ReceiptCount v2)"
+
+    Write-Host "Querying the Service Bus queue for backlog and dead-letter counts..."
+    $serviceBusNamespace = [string](az servicebus namespace list --resource-group $ResourceGroup --query "[0].name" --output tsv).Trim()
+    $queueJson = az servicebus queue show `
+        --resource-group $ResourceGroup `
+        --namespace-name $serviceBusNamespace `
+        --name order-events `
+        --query "{active:countDetails.activeMessageCount, dlq:countDetails.deadLetterMessageCount}" `
+        --output json
+    if ($LASTEXITCODE -ne 0) { throw "Service Bus queue query failed." }
+    $queueActive = [string]($queueJson | jq -er '.active').Trim()
+    $queueDlq = [string]($queueJson | jq -er '.dlq').Trim()
+    Write-Host "Service Bus queue: active=$queueActive dlq=$queueDlq"
+
+    if ($queueActive -ne '0') {
+        Write-Error "FAIL: Service Bus queue has $queueActive active message(s); expected zero."
+        $failures++
+    }
+
+    if ($queueDlq -ne '0') {
+        Write-Error "FAIL: Service Bus queue has $queueDlq dead-letter (DLQ) message(s); expected zero."
+        $failures++
+    }
+
+    Write-Host "Querying Application Insights for UnsupportedReceiptSchemaError exceptions since deployment..."
+    $appInsightsName = [string](az resource list --resource-group $ResourceGroup --resource-type "Microsoft.Insights/components" --query "[0].name" --output tsv).Trim()
+    $exceptionQuery = "exceptions | where type == 'UnsupportedReceiptSchemaError' | where timestamp > datetime($deployedAtUtc) | summarize count()"
+    $exceptionsJson = az monitor app-insights query `
+        --app $appInsightsName `
+        --resource-group $ResourceGroup `
+        --analytics-query $exceptionQuery `
+        --output json
+    if ($LASTEXITCODE -ne 0) { throw "Application Insights query failed." }
+    $exceptionCount = [string]($exceptionsJson | jq -er '.tables[0].rows[0][0]').Trim()
+    Write-Host "UnsupportedReceiptSchemaError exceptions since deployment: $exceptionCount"
+
+    if ($exceptionCount -ne '0') {
+        Write-Error "FAIL: $exceptionCount UnsupportedReceiptSchemaError exception(s) occurred after DEPLOYED_AT_UTC ($deployedAtUtc)."
+        $failures++
+    }
+
+    if ($failures -ne 0) {
+        throw "Validation failed ($failures issue(s))."
+    }
+
+    Write-Host ""
+    Write-Host "========================================"
+    Write-Host "  Validation passed: incident fully recovered"
+    Write-Host "========================================"
+}
+finally {
+    Remove-Item -Force $statusFile.FullName -ErrorAction SilentlyContinue
+}

--- a/scenarios/azure-boards-copilot-handover/scripts/validate.ps1
+++ b/scenarios/azure-boards-copilot-handover/scripts/validate.ps1
@@ -118,18 +118,21 @@ try {
 
     $failures = 0
 
+    # Uses explicit stderr writes (not Write-Error) so multiple simultaneous
+    # failures are aggregated like Bash instead of Write-Error's terminating
+    # error under $ErrorActionPreference = 'Stop' aborting after the first one.
     if ($deployedCommitSha -ne $localHeadSha) {
-        Write-Error "FAIL: deployed sha '$deployedCommitSha' does not match local HEAD sha '$localHeadSha'."
+        [Console]::Error.WriteLine("FAIL: deployed sha '$deployedCommitSha' does not match local HEAD sha '$localHeadSha'.")
         $failures++
     }
 
     if ($incidentBatchInjected -ne 'true') {
-        Write-Error "FAIL: the incident batch has not completed (incidentBatchInjected=$incidentBatchInjected)."
+        [Console]::Error.WriteLine("FAIL: the incident batch has not completed (incidentBatchInjected=$incidentBatchInjected).")
         $failures++
     }
 
     if ($normalizedReceiptCount -ne '23' -or $v1ReceiptCount -ne '3' -or $v2ReceiptCount -ne '20') {
-        Write-Error "FAIL: receipt split is not exactly 3 v1 / 20 v2 (23 total); got v1=$v1ReceiptCount v2=$v2ReceiptCount total=$normalizedReceiptCount."
+        [Console]::Error.WriteLine("FAIL: receipt split is not exactly 3 v1 / 20 v2 (23 total); got v1=$v1ReceiptCount v2=$v2ReceiptCount total=$normalizedReceiptCount.")
         $failures++
     }
 
@@ -153,18 +156,18 @@ try {
     Write-Host "Service Bus queue: active=$queueActive dlq=$queueDlq"
 
     if ($queueActive -ne '0') {
-        Write-Error "FAIL: Service Bus queue has $queueActive active message(s); expected zero."
+        [Console]::Error.WriteLine("FAIL: Service Bus queue has $queueActive active message(s); expected zero.")
         $failures++
     }
 
     if ($queueDlq -ne '0') {
-        Write-Error "FAIL: Service Bus queue has $queueDlq dead-letter (DLQ) message(s); expected zero."
+        [Console]::Error.WriteLine("FAIL: Service Bus queue has $queueDlq dead-letter (DLQ) message(s); expected zero.")
         $failures++
     }
 
     Write-Host "Querying Application Insights for UnsupportedReceiptSchemaError exceptions since deployment..."
     $appInsightsName = [string](az resource list --resource-group $ResourceGroup --resource-type "Microsoft.Insights/components" --query "[0].name" --output tsv).Trim()
-    $exceptionQuery = "exceptions | where type == 'UnsupportedReceiptSchemaError' | where timestamp > datetime($deployedAtUtc) | summarize count()"
+    $exceptionQuery = "exceptions | where type endswith 'UnsupportedReceiptSchemaError' | where timestamp > datetime($deployedAtUtc) | summarize count()"
     $exceptionsJson = az monitor app-insights query `
         --app $appInsightsName `
         --resource-group $ResourceGroup `
@@ -175,7 +178,7 @@ try {
     Write-Host "UnsupportedReceiptSchemaError exceptions since deployment: $exceptionCount"
 
     if ($exceptionCount -ne '0') {
-        Write-Error "FAIL: $exceptionCount UnsupportedReceiptSchemaError exception(s) occurred after DEPLOYED_AT_UTC ($deployedAtUtc)."
+        [Console]::Error.WriteLine("FAIL: $exceptionCount UnsupportedReceiptSchemaError exception(s) occurred after DEPLOYED_AT_UTC ($deployedAtUtc).")
         $failures++
     }
 

--- a/scenarios/azure-boards-copilot-handover/scripts/validate.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/validate.sh
@@ -1,4 +1,207 @@
 #!/usr/bin/env bash
+# Proves the Azure Boards Copilot Handover incident has been fully recovered:
+# the deployed commit matches local HEAD, the incident batch is completed,
+# receipts split exactly 3 v1 / 20 v2 (23 total), the Service Bus queue has
+# zero active and zero dead-lettered messages, and no
+# UnsupportedReceiptSchemaError exceptions occurred after the deployment
+# timestamp. Query failures fail validation; nothing here repairs the app.
 set -euo pipefail
-echo "Scenario validate is a no-op in the template."
-exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+WORKLOAD="srelabboardshandover"
+RESOURCE_GROUP=""
+RESOURCE_GROUP_SET=false
+FUNCTION_APP=""
+
+usage() {
+  cat <<'EOF'
+Usage: validate.sh [-w|--workload <name>] [-g|--resource-group <name>] [-a|--app-name <name>] [-s|--subscription-id <id>] [-h|--help]
+
+Proves the incident is fully recovered: deployed SHA matches local HEAD, the
+incident is completed, receipts split exactly 3 v1 / 20 v2, the Service Bus
+queue is empty (zero active, zero dead-lettered), and no
+UnsupportedReceiptSchemaError exceptions occurred after deployment.
+
+Options:
+  -w, --workload         Workload name used to derive <workload>-rg (default: srelabboardshandover)
+  -g, --resource-group   Resource group containing the Function app (default: <workload>-rg)
+  -a, --app-name         Function app name (default: discovered via az functionapp list)
+  -s, --subscription-id  Azure subscription ID (default: AZURE_SUBSCRIPTION_ID or active subscription)
+  -h, --help             Show this help
+EOF
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "$value" ] || [[ "$value" == -* ]]; then
+    echo "Missing value for $option." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -w|--workload)
+      require_option_value "$1" "${2:-}"
+      WORKLOAD="$2"
+      shift 2
+      ;;
+    -g|--resource-group)
+      require_option_value "$1" "${2:-}"
+      RESOURCE_GROUP="$2"
+      RESOURCE_GROUP_SET=true
+      shift 2
+      ;;
+    -a|--app-name)
+      require_option_value "$1" "${2:-}"
+      FUNCTION_APP="$2"
+      shift 2
+      ;;
+    -s|--subscription-id)
+      require_option_value "$1" "${2:-}"
+      export AZURE_SUBSCRIPTION_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$RESOURCE_GROUP_SET" = false ]; then
+  RESOURCE_GROUP="${WORKLOAD}-rg"
+fi
+
+echo "========================================"
+echo "  Azure Boards Copilot Handover — Validate"
+echo "========================================"
+echo "Resource group: $RESOURCE_GROUP"
+
+for required_command in az curl jq git; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "Required command not found: $required_command" >&2
+    exit 1
+  fi
+done
+
+requested_subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+if [ -n "$requested_subscription_id" ] && ! az account set --subscription "$requested_subscription_id"; then echo "Unable to select Azure subscription '$requested_subscription_id'. Run 'az login', then run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+active_subscription_id=$(az account show --query id --output tsv) || { echo "Azure CLI is not authenticated. Run 'az login' and try again." >&2; exit 1; }
+active_subscription_name=$(az account show --query name --output tsv) || { echo "Unable to read the active Azure subscription name." >&2; exit 1; }
+if [ -z "$active_subscription_id" ] || [ -z "$active_subscription_name" ]; then echo "Unable to read the active Azure subscription. Run 'az login' and try again." >&2; exit 1; fi
+if [ -n "$requested_subscription_id" ] && [ "$active_subscription_id" != "$requested_subscription_id" ]; then echo "Azure subscription mismatch: requested '$requested_subscription_id', but active subscription is '$active_subscription_id'. Run: az account set --subscription \"$requested_subscription_id\"" >&2; exit 1; fi
+echo "Azure subscription: $active_subscription_name ($active_subscription_id)"
+
+if [ -z "$FUNCTION_APP" ]; then
+  FUNCTION_APP=$(az functionapp list --resource-group "$RESOURCE_GROUP" --query "[0].name" --output tsv)
+  if [ -z "$FUNCTION_APP" ]; then
+    echo "Unable to discover a Function app in resource group '$RESOURCE_GROUP'. Pass --app-name explicitly." >&2
+    exit 1
+  fi
+fi
+echo "Function app: $FUNCTION_APP"
+
+LOCAL_HEAD_SHA="$(cd "$REPO_ROOT" && git rev-parse HEAD)"
+
+FUNCTION_HOSTNAME=$(az functionapp show --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query defaultHostName --output tsv)
+FUNCTION_KEY=$(az functionapp keys list --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query "functionKeys.default" --output tsv)
+
+STATUS_FILE="$(mktemp)"
+trap 'rm -f "$STATUS_FILE"' EXIT
+curl -sS -o "$STATUS_FILE" -w '%{http_code}' "https://$FUNCTION_HOSTNAME/api/status?code=$FUNCTION_KEY" >/dev/null
+
+DEPLOYED_COMMIT_SHA=$(jq -er '.deployedCommitSha // empty' "$STATUS_FILE")
+DEPLOYED_AT_UTC=$(jq -er '.deployedAtUtc // empty' "$STATUS_FILE")
+INCIDENT_BATCH_INJECTED=$(jq -er '.incidentBatchInjected' "$STATUS_FILE")
+NORMALIZED_RECEIPT_COUNT=$(jq -er '.normalizedReceiptCount' "$STATUS_FILE")
+V1_RECEIPT_COUNT=$(jq -er '.v1ReceiptCount' "$STATUS_FILE")
+V2_RECEIPT_COUNT=$(jq -er '.v2ReceiptCount' "$STATUS_FILE")
+
+echo ""
+echo "Deployed commit SHA: $DEPLOYED_COMMIT_SHA"
+echo "Local HEAD SHA:      $LOCAL_HEAD_SHA"
+
+failures=0
+
+if [ "$DEPLOYED_COMMIT_SHA" != "$LOCAL_HEAD_SHA" ]; then
+  echo "FAIL: deployed sha '$DEPLOYED_COMMIT_SHA' does not match local HEAD sha '$LOCAL_HEAD_SHA'." >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$INCIDENT_BATCH_INJECTED" != "true" ]; then
+  echo "FAIL: the incident batch has not completed (incidentBatchInjected=$INCIDENT_BATCH_INJECTED)." >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$NORMALIZED_RECEIPT_COUNT" != "23" ] || [ "$V1_RECEIPT_COUNT" != "3" ] || [ "$V2_RECEIPT_COUNT" != "20" ]; then
+  echo "FAIL: receipt split is not exactly 3 v1 / 20 v2 (23 total); got v1=$V1_RECEIPT_COUNT v2=$V2_RECEIPT_COUNT total=$NORMALIZED_RECEIPT_COUNT." >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "" >&2
+  echo "Validation failed ($failures issue(s)) before querying Azure telemetry." >&2
+  exit 1
+fi
+
+echo "Receipts: $NORMALIZED_RECEIPT_COUNT total ($V1_RECEIPT_COUNT v1 / $V2_RECEIPT_COUNT v2)"
+
+echo "Querying the Service Bus queue for backlog and dead-letter counts..."
+SERVICE_BUS_NAMESPACE=$(az servicebus namespace list --resource-group "$RESOURCE_GROUP" --query "[0].name" --output tsv)
+QUEUE_JSON=$(az servicebus queue show \
+  --resource-group "$RESOURCE_GROUP" \
+  --namespace-name "$SERVICE_BUS_NAMESPACE" \
+  --name order-events \
+  --query "{active:countDetails.activeMessageCount, dlq:countDetails.deadLetterMessageCount}" \
+  --output json)
+QUEUE_ACTIVE=$(jq -er '.active' <<<"$QUEUE_JSON")
+QUEUE_DLQ=$(jq -er '.dlq' <<<"$QUEUE_JSON")
+echo "Service Bus queue: active=$QUEUE_ACTIVE dlq=$QUEUE_DLQ"
+
+if [ "$QUEUE_ACTIVE" != "0" ]; then
+  echo "FAIL: Service Bus queue has $QUEUE_ACTIVE active message(s); expected zero." >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$QUEUE_DLQ" != "0" ]; then
+  echo "FAIL: Service Bus queue has $QUEUE_DLQ dead-letter (DLQ) message(s); expected zero." >&2
+  failures=$((failures + 1))
+fi
+
+echo "Querying Application Insights for UnsupportedReceiptSchemaError exceptions since deployment..."
+APP_INSIGHTS_NAME=$(az resource list --resource-group "$RESOURCE_GROUP" --resource-type "Microsoft.Insights/components" --query "[0].name" --output tsv)
+EXCEPTION_QUERY="exceptions | where type == 'UnsupportedReceiptSchemaError' | where timestamp > datetime($DEPLOYED_AT_UTC) | summarize count()"
+EXCEPTIONS_JSON=$(az monitor app-insights query \
+  --app "$APP_INSIGHTS_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --analytics-query "$EXCEPTION_QUERY" \
+  --output json)
+EXCEPTION_COUNT=$(jq -er '.tables[0].rows[0][0]' <<<"$EXCEPTIONS_JSON")
+echo "UnsupportedReceiptSchemaError exceptions since deployment: $EXCEPTION_COUNT"
+
+if [ "$EXCEPTION_COUNT" != "0" ]; then
+  echo "FAIL: $EXCEPTION_COUNT UnsupportedReceiptSchemaError exception(s) occurred after DEPLOYED_AT_UTC ($DEPLOYED_AT_UTC)." >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "" >&2
+  echo "Validation failed ($failures issue(s))." >&2
+  exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "  Validation passed: incident fully recovered"
+echo "========================================"

--- a/scenarios/azure-boards-copilot-handover/scripts/validate.sh
+++ b/scenarios/azure-boards-copilot-handover/scripts/validate.sh
@@ -123,7 +123,11 @@ curl -sS -o "$STATUS_FILE" -w '%{http_code}' "https://$FUNCTION_HOSTNAME/api/sta
 
 DEPLOYED_COMMIT_SHA=$(jq -er '.deployedCommitSha // empty' "$STATUS_FILE")
 DEPLOYED_AT_UTC=$(jq -er '.deployedAtUtc // empty' "$STATUS_FILE")
-INCIDENT_BATCH_INJECTED=$(jq -er '.incidentBatchInjected' "$STATUS_FILE")
+# Not `-e`: `incidentBatchInjected` is a legitimate JSON boolean, and jq's
+# `-e` treats a `false` result as a jq-level failure. Under `set -e` that
+# would abort the script here instead of letting the aggregation below emit
+# the intended incident-not-completed diagnostic and keep checking.
+INCIDENT_BATCH_INJECTED=$(jq -r '.incidentBatchInjected' "$STATUS_FILE")
 NORMALIZED_RECEIPT_COUNT=$(jq -er '.normalizedReceiptCount' "$STATUS_FILE")
 V1_RECEIPT_COUNT=$(jq -er '.v1ReceiptCount' "$STATUS_FILE")
 V2_RECEIPT_COUNT=$(jq -er '.v2ReceiptCount' "$STATUS_FILE")
@@ -181,7 +185,7 @@ fi
 
 echo "Querying Application Insights for UnsupportedReceiptSchemaError exceptions since deployment..."
 APP_INSIGHTS_NAME=$(az resource list --resource-group "$RESOURCE_GROUP" --resource-type "Microsoft.Insights/components" --query "[0].name" --output tsv)
-EXCEPTION_QUERY="exceptions | where type == 'UnsupportedReceiptSchemaError' | where timestamp > datetime($DEPLOYED_AT_UTC) | summarize count()"
+EXCEPTION_QUERY="exceptions | where type endswith 'UnsupportedReceiptSchemaError' | where timestamp > datetime($DEPLOYED_AT_UTC) | summarize count()"
 EXCEPTIONS_JSON=$(az monitor app-insights query \
   --app "$APP_INSIGHTS_NAME" \
   --resource-group "$RESOURCE_GROUP" \

--- a/scripts/scenario-tools/test/azure-boards-copilot-handover-lifecycle.test.js
+++ b/scripts/scenario-tools/test/azure-boards-copilot-handover-lifecycle.test.js
@@ -1,0 +1,644 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { after, test } from 'node:test';
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..');
+const scenarioRoot = resolve(repositoryRoot, 'scenarios', 'azure-boards-copilot-handover');
+const scriptsDirectory = resolve(scenarioRoot, 'scripts');
+const mockedLifecyclePath = `${resolve(import.meta.dirname, 'fixtures', 'lifecycle-bin')}:${process.env.PATH}`;
+const scratchRoot = resolve(import.meta.dirname, '.tmp-lifecycle-scratch');
+mkdirSync(scratchRoot, { recursive: true });
+after(() => rmSync(scratchRoot, { recursive: true, force: true }));
+
+function scratchDir() {
+  return mkdtempSync(resolve(scratchRoot, 'sre-lifecycle-'));
+}
+
+const localHeadSha = spawnSync('git', ['rev-parse', 'HEAD'], {
+  cwd: repositoryRoot,
+  encoding: 'utf8',
+}).stdout.trim();
+
+function readScript(name) {
+  return readFileSync(resolve(scriptsDirectory, name), 'utf8');
+}
+
+function runBash(script, args = [], env = {}) {
+  return spawnSync('bash', [resolve(scriptsDirectory, script), ...args], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: mockedLifecyclePath, ...env },
+  });
+}
+
+function runPowerShell(script, args = [], env = {}) {
+  return spawnSync(
+    'pwsh',
+    ['-NoProfile', '-File', resolve(scriptsDirectory, script), ...args],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: mockedLifecyclePath, ...env },
+    }
+  );
+}
+
+function bothShells(script, bashArgs, powershellArgs, env = {}) {
+  const powershellScript = script.replace(/\.sh$/, '.ps1');
+  return [
+    ['Bash', runBash(script, bashArgs, env)],
+    ['PowerShell', runPowerShell(powershellScript, powershellArgs, env)],
+  ];
+}
+
+// A status body reporting a fully-recovered incident: deployed SHA matches
+// local HEAD, the incident batch is injected, and receipts split 3 v1 / 20 v2.
+function healthyStatusBody(overrides = {}) {
+  return JSON.stringify({
+    incidentBatchId: 'v2-incident-orders',
+    incidentBatchInjected: true,
+    deployedCommitSha: localHeadSha,
+    deployedAtUtc: '2026-08-17T13:52:55Z',
+    normalizedReceiptCount: 23,
+    v1ReceiptCount: 3,
+    v2ReceiptCount: 20,
+    ...overrides,
+  });
+}
+
+test('All new lifecycle scripts exist, are paired, and Bash scripts are executable', () => {
+  for (const base of ['setup', 'deploy', 'inject', 'validate', 'cleanup']) {
+    const bashPath = resolve(scriptsDirectory, `${base}.sh`);
+    const powershellPath = resolve(scriptsDirectory, `${base}.ps1`);
+
+    assert.ok(existsSync(bashPath), `missing ${base}.sh`);
+    assert.ok(existsSync(powershellPath), `missing ${base}.ps1`);
+    assert.notEqual(
+      statSync(bashPath).mode & 0o111,
+      0,
+      `${base}.sh must be executable`
+    );
+  }
+});
+
+test('Lifecycle scripts no longer describe themselves as no-op placeholders', () => {
+  for (const base of ['setup', 'deploy', 'inject', 'validate', 'cleanup']) {
+    assert.doesNotMatch(readScript(`${base}.sh`), /no-op in the template/);
+    assert.doesNotMatch(readScript(`${base}.ps1`), /no-op in the template/);
+  }
+});
+
+test('setup/deploy/inject/validate/cleanup default to the approved workload, resource group, and location', () => {
+  for (const base of ['setup', 'deploy', 'inject', 'validate', 'cleanup']) {
+    const bash = readScript(`${base}.sh`);
+    const powershell = readScript(`${base}.ps1`);
+
+    assert.match(bash, /srelabboardshandover/);
+    assert.match(powershell, /srelabboardshandover/);
+  }
+
+  const setupBash = readScript('setup.sh');
+  assert.match(setupBash, /-rg/);
+  assert.match(setupBash, /eastus2/);
+});
+
+test('setup and cleanup help documents workload, resource group, subscription, and location parity', () => {
+  for (const [shell, result] of bothShells('setup.sh', ['--help'], ['-Help'])) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.match(result.stdout, /workload/i, shell);
+    assert.match(result.stdout, /location/i, shell);
+    assert.match(result.stdout, /subscription-id/i, shell);
+  }
+
+  for (const [shell, result] of bothShells('cleanup.sh', ['--help'], ['-Help'])) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.match(result.stdout, /workload/i, shell);
+    assert.match(result.stdout, /resource-group/i, shell);
+    assert.match(result.stdout, /--yes/i, shell);
+    assert.match(result.stdout, /--dry-run/i, shell);
+  }
+});
+
+test('deploy, inject, and validate help document app-name overrides', () => {
+  for (const base of ['deploy', 'inject', 'validate']) {
+    for (const [shell, result] of bothShells(`${base}.sh`, ['--help'], ['-Help'])) {
+      assert.equal(result.status, 0, `${shell} ${base}: ${result.stderr}`);
+      assert.match(result.stdout, /app-name/i, `${shell} ${base}`);
+      assert.match(result.stdout, /resource-group/i, `${shell} ${base}`);
+    }
+  }
+});
+
+test('Every new lifecycle script rejects unknown options instead of silently continuing', () => {
+  for (const base of ['setup', 'deploy', 'inject', 'validate', 'cleanup']) {
+    for (const [shell, result] of bothShells(
+      `${base}.sh`,
+      ['--not-a-real-option'],
+      ['--not-a-real-option']
+    )) {
+      assert.notEqual(result.status, 0, `${shell} ${base} accepted an unknown option`);
+    }
+  }
+});
+
+test('Cleanup only ever deletes the derived scenario resource group and never touches GitHub or Azure Boards', () => {
+  for (const base of ['cleanup.sh', 'cleanup.ps1']) {
+    const source = readScript(base);
+    assert.doesNotMatch(source, /\bgh\s+/);
+    assert.doesNotMatch(source, /\baz\s+boards\b/i);
+  }
+});
+
+test('Cleanup dry-run reports the derived resource group without deleting it', () => {
+  for (const [shell, result] of bothShells(
+    'cleanup.sh',
+    ['--dry-run'],
+    ['--dry-run']
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.match(result.stdout, /srelabboardshandover-rg/, shell);
+    assert.match(result.stdout, /Dry run/i, shell);
+  }
+});
+
+test('Cleanup derives rg-<workload>-rg style resource group from a custom workload', () => {
+  for (const [shell, result] of bothShells(
+    'cleanup.sh',
+    ['--workload', 'custom-workload', '--dry-run'],
+    ['-Workload', 'custom-workload', '--dry-run']
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.match(result.stdout, /custom-workload-rg/, shell);
+  }
+});
+
+test('Cleanup honors an explicit --resource-group override', () => {
+  for (const [shell, result] of bothShells(
+    'cleanup.sh',
+    ['--resource-group', 'rg-custom', '--dry-run'],
+    ['-ResourceGroup', 'rg-custom', '--dry-run']
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.match(result.stdout, /rg-custom/, shell);
+    assert.doesNotMatch(result.stdout, /srelabboardshandover-rg/, shell);
+  }
+});
+
+test('Cleanup skips the confirmation prompt with --yes and deletes only the scenario resource group', () => {
+  for (const [shell, result] of bothShells(
+    'cleanup.sh',
+    ['--workload', 'custom-workload', '--yes'],
+    ['-Workload', 'custom-workload', '--yes']
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.doesNotMatch(result.stdout, /\[y\/N\]/, shell);
+  }
+});
+
+test('Cleanup verifies the requested Azure subscription before deleting', () => {
+  const bash = readScript('cleanup.sh');
+  const powershell = readScript('cleanup.ps1');
+
+  assert.match(bash, /az account set --subscription/);
+  assert.match(bash, /az account show/);
+  assert.match(bash, /Azure subscription mismatch/);
+  assert.match(powershell, /az account set --subscription/);
+  assert.match(powershell, /az account show/);
+  assert.match(powershell, /Azure subscription mismatch/);
+});
+
+test('Deploy stamps the current git HEAD SHA and a UTC timestamp as Function app settings', () => {
+  for (const shell of ['Bash', 'PowerShell']) {
+    const logPath = resolve(scratchDir(), 'az.log');
+    const result =
+      shell === 'Bash'
+        ? runBash(
+            'deploy.sh',
+            ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+            { LIFECYCLE_AZ_LOG_PATH: logPath, LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody() }
+          )
+        : runPowerShell(
+            'deploy.ps1',
+            ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+            { LIFECYCLE_AZ_LOG_PATH: logPath, LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody() }
+          );
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}\n${result.stdout}`);
+    const azLog = readFileSync(logPath, 'utf8');
+    assert.match(
+      azLog,
+      new RegExp(`functionapp config appsettings set.*DEPLOYED_COMMIT_SHA=${localHeadSha}`),
+      shell
+    );
+    assert.match(
+      azLog,
+      /DEPLOYED_AT_UTC=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/,
+      shell
+    );
+  }
+});
+
+test('Deploy sets remote build only when it is not already enabled', () => {
+  const alreadyEnabledLog = resolve(scratchDir(), 'az.log');
+  const notEnabledLog = resolve(scratchDir(), 'az.log');
+
+  const alreadyEnabled = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_AZ_LOG_PATH: alreadyEnabledLog,
+      LIFECYCLE_AZ_SCM_BUILD_SETTING: 'true',
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+    }
+  );
+  assert.equal(alreadyEnabled.status, 0, alreadyEnabled.stderr);
+  assert.doesNotMatch(
+    readFileSync(alreadyEnabledLog, 'utf8'),
+    /appsettings set[^\n]*SCM_DO_BUILD_DURING_DEPLOYMENT/
+  );
+
+  const notEnabled = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_AZ_LOG_PATH: notEnabledLog,
+      LIFECYCLE_AZ_SCM_BUILD_SETTING: '',
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+    }
+  );
+  assert.equal(notEnabled.status, 0, notEnabled.stderr);
+  assert.match(
+    readFileSync(notEnabledLog, 'utf8'),
+    /functionapp config appsettings set.*SCM_DO_BUILD_DURING_DEPLOYMENT=true/
+  );
+});
+
+test('Deploy runs the app baseline quality gates from the current checkout', () => {
+  const bash = readScript('deploy.sh');
+  const powershell = readScript('deploy.ps1');
+
+  for (const source of [bash, powershell]) {
+    assert.match(source, /ruff["'\s]+format["'\s]+--check/);
+    assert.match(source, /ruff["'\s]+check/);
+    assert.match(source, /mypy/);
+    assert.match(source, /pytest/);
+  }
+});
+
+test('Deploy zips only runtime files (excludes venv and tests) and cleans temp files', () => {
+  const keepTempDirectoryLog = resolve(
+    scratchDir(),
+    'keep-temp-dir.txt'
+  );
+
+  const result = runBash(
+    'deploy.sh',
+    [
+      '--resource-group',
+      'srelabboardshandover-rg',
+      '--app-name',
+      'test-func',
+      '--keep-temp',
+    ],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      DEPLOY_KEEP_TEMP_DIR_LOG: keepTempDirectoryLog,
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const keptDirectory = readFileSync(keepTempDirectoryLog, 'utf8').trim();
+  assert.ok(existsSync(keptDirectory), 'kept temp directory should still exist');
+
+  const zipList = spawnSync('unzip', ['-l', resolve(keptDirectory, 'app.zip')], {
+    encoding: 'utf8',
+  });
+  assert.equal(zipList.status, 0, zipList.stderr);
+  assert.match(zipList.stdout, /function_app\.py/);
+  assert.match(zipList.stdout, /host\.json/);
+  assert.match(zipList.stdout, /order_events\/workshop\.py/);
+  assert.doesNotMatch(zipList.stdout, /tests\//);
+  assert.doesNotMatch(zipList.stdout, /\.venv\//);
+  assert.doesNotMatch(zipList.stdout, /__pycache__/);
+
+  rmSync(keptDirectory, { recursive: true, force: true });
+
+  const cleanupResult = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    { LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody() }
+  );
+  assert.equal(cleanupResult.status, 0, cleanupResult.stderr);
+  assert.doesNotMatch(cleanupResult.stdout, /app\.zip/);
+});
+
+test('Deploy waits (bounded) for the keyed status endpoint to report the deployed SHA', () => {
+  const counterFile = resolve(scratchDir(), 'counter');
+
+  const eventuallySucceeds = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_COUNTER_FILE: counterFile,
+      LIFECYCLE_CURL_STATUS_PENDING_ATTEMPTS: '2',
+      LIFECYCLE_CURL_STATUS_PENDING_BODY: healthyStatusBody({ deployedCommitSha: 'stale-sha' }),
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      STATUS_POLL_ATTEMPTS: '5',
+      STATUS_POLL_DELAY_SECONDS: '0',
+    }
+  );
+
+  assert.equal(eventuallySucceeds.status, 0, eventuallySucceeds.stderr);
+  rmSync(counterFile, { force: true });
+
+  const neverSucceeds = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_COUNTER_FILE: counterFile,
+      LIFECYCLE_CURL_STATUS_PENDING_ATTEMPTS: '999',
+      LIFECYCLE_CURL_STATUS_PENDING_BODY: healthyStatusBody({ deployedCommitSha: 'stale-sha' }),
+      STATUS_POLL_ATTEMPTS: '2',
+      STATUS_POLL_DELAY_SECONDS: '0',
+    }
+  );
+
+  assert.notEqual(neverSucceeds.status, 0);
+  assert.match(neverSucceeds.stderr, /timed out|did not report/i);
+});
+
+test('Setup provisions the subscription-scope Bicep template and captures its outputs', () => {
+  const bash = readScript('setup.sh');
+  const powershell = readScript('setup.ps1');
+
+  assert.match(bash, /az deployment sub create/);
+  assert.match(bash, /infra\/bicep\/main\.bicep/);
+  assert.match(bash, /properties\.outputs/);
+  assert.match(powershell, /az deployment sub create/);
+  assert.match(powershell, /infra\/bicep\/main\.bicep/);
+});
+
+test('Setup deploys the current checkout, seeds v1 controls exactly once, and prints keyed URLs without the seed URL', () => {
+  for (const [shell, result] of bothShells(
+    'setup.sh',
+    ['--workload', 'srelabboardshandover'],
+    ['-Workload', 'srelabboardshandover'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      RETRY_DELAY_SECONDS: '0',
+    }
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /status\?code=/, shell);
+    assert.match(result.stdout, /submit-v2-orders\?code=/, shell);
+    assert.doesNotMatch(result.stdout, /seed-v1-controls\?code=/, shell);
+    assert.doesNotMatch(result.stdout, /test-function-key/, `${shell} must never print the raw key value`);
+  }
+});
+
+test('Setup retries seeding v1 controls with bounded attempts for Function startup/RBAC propagation', () => {
+  const succeeds = runBash(
+    'setup.sh',
+    ['--workload', 'srelabboardshandover'],
+    {
+      LIFECYCLE_AZ_KEYS_FAIL_ATTEMPTS: '2',
+      LIFECYCLE_AZ_KEYS_COUNTER_FILE: resolve(
+        scratchDir(),
+        'keys-counter'
+      ),
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      RETRY_ATTEMPTS: '5',
+      RETRY_DELAY_SECONDS: '0',
+    }
+  );
+  assert.equal(succeeds.status, 0, succeeds.stderr);
+
+  const timesOut = runBash(
+    'setup.sh',
+    ['--workload', 'srelabboardshandover'],
+    {
+      LIFECYCLE_AZ_KEYS_FAIL_ATTEMPTS: '999',
+      LIFECYCLE_AZ_KEYS_COUNTER_FILE: resolve(
+        scratchDir(),
+        'keys-counter'
+      ),
+      RETRY_ATTEMPTS: '2',
+      RETRY_DELAY_SECONDS: '0',
+    }
+  );
+  assert.notEqual(timesOut.status, 0);
+  assert.match(timesOut.stderr, /timed out|failed after/i);
+});
+
+test('Setup seeding v1 controls is idempotent: a repeat call reports already-injected without duplicating', () => {
+  const logPath = resolve(scratchDir(), 'curl.log');
+  const result = runBash(
+    'setup.sh',
+    ['--workload', 'srelabboardshandover'],
+    {
+      LIFECYCLE_CURL_SEED_CODE: '200',
+      LIFECYCLE_CURL_SEED_BODY: '{"controlBatchAlreadyInjected":true,"eventsEnqueued":0}',
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_CURL_LOG_PATH: logPath,
+      RETRY_DELAY_SECONDS: '0',
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(readFileSync(logPath, 'utf8'), /seed-v1-controls\?code=/);
+});
+
+test('Inject submits the keyed v2 incident batch, treats a fresh 202 as success, and shows status', () => {
+  for (const [shell, result] of bothShells(
+    'inject.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+    {
+      LIFECYCLE_CURL_SUBMIT_CODE: '202',
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({ incidentBatchInjected: true }),
+    }
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /incidentBatchInjected/, shell);
+  }
+});
+
+test('Inject treats a completed-repeat 200 as success (idempotent, recoverable)', () => {
+  for (const [shell, result] of bothShells(
+    'inject.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+    {
+      LIFECYCLE_CURL_SUBMIT_CODE: '200',
+      LIFECYCLE_CURL_SUBMIT_BODY:
+        '{"incidentBatchAlreadyInjected":true,"eventsEnqueued":0}',
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({ incidentBatchInjected: true }),
+    }
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}`);
+    assert.match(result.stdout, /incidentBatchInjected/, shell);
+  }
+});
+
+test('Inject fails loudly on an unexpected submit-v2-orders response', () => {
+  for (const [shell, result] of bothShells(
+    'inject.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+    { LIFECYCLE_CURL_SUBMIT_CODE: '500', LIFECYCLE_CURL_SUBMIT_BODY: '{"error":"boom"}' }
+  )) {
+    assert.notEqual(result.status, 0, shell);
+  }
+});
+
+test('Validate proves the deployed SHA matches local HEAD, the incident is completed, and receipts split 3 v1 / 20 v2', () => {
+  for (const [shell, result] of bothShells(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  )) {
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /23/, shell);
+  }
+});
+
+test('Validate fails when the deployed SHA does not match local HEAD', () => {
+  const result = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({ deployedCommitSha: 'not-the-local-head' }),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /sha/i);
+});
+
+test('Validate fails when the receipt split is not exactly 3 v1 and 20 v2', () => {
+  const result = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({ v2ReceiptCount: 19, normalizedReceiptCount: 22 }),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /receipt/i);
+});
+
+test('Validate fails when the incident batch is not yet completed', () => {
+  const result = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({ incidentBatchInjected: false }),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  );
+
+  assert.notEqual(result.status, 0);
+});
+
+test('Validate fails on non-zero Service Bus active or dead-letter counts', () => {
+  const activeBacklog = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '4',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  );
+  assert.notEqual(activeBacklog.status, 0);
+  assert.match(activeBacklog.stderr, /active/i);
+
+  const deadLettered = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '2',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  );
+  assert.notEqual(deadLettered.status, 0);
+  assert.match(deadLettered.stderr, /dead-letter|dlq/i);
+});
+
+test('Validate fails when UnsupportedReceiptSchemaError exceptions occurred after DEPLOYED_AT_UTC', () => {
+  const result = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '3',
+    }
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /UnsupportedReceiptSchemaError|exception/i);
+});
+
+test('Validate queries the Service Bus queue and Application Insights explicitly, and fails loudly when either query fails', () => {
+  const bash = readScript('validate.sh');
+  assert.match(bash, /az servicebus queue show/);
+  assert.match(bash, /az monitor app-insights query/);
+
+  const queueQueryFails = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_FAIL_QUEUE_SHOW: '1',
+    }
+  );
+  assert.notEqual(queueQueryFails.status, 0);
+  assert.match(queueQueryFails.stderr, /simulated Service Bus queue query failure/);
+
+  const appInsightsQueryFails = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_FAIL_APP_INSIGHTS_QUERY: '1',
+    }
+  );
+  assert.notEqual(appInsightsQueryFails.status, 0);
+  assert.match(appInsightsQueryFails.stderr, /simulated Application Insights query failure/);
+});
+
+test('setup, deploy, inject, validate, and cleanup never persist the Function host key to disk', () => {
+  for (const base of ['setup.sh', 'setup.ps1', 'deploy.sh', 'deploy.ps1', 'inject.sh', 'inject.ps1', 'validate.sh', 'validate.ps1']) {
+    const source = readScript(base);
+    assert.doesNotMatch(
+      source,
+      />\s*"?\$?\(?(?:HOST_)?KEY\)?"?\s*$/m,
+      `${base} must never redirect the function key to a file`
+    );
+    assert.doesNotMatch(source, /Set-Content.*[Kk]ey/);
+    assert.doesNotMatch(source, /Out-File.*[Kk]ey/);
+  }
+});

--- a/scripts/scenario-tools/test/azure-boards-copilot-handover-lifecycle.test.js
+++ b/scripts/scenario-tools/test/azure-boards-copilot-handover-lifecycle.test.js
@@ -518,6 +518,34 @@ test('Setup retries seeding v1 controls with bounded attempts for Function start
   assert.match(timesOut.stderr, /timed out|failed after/i);
 });
 
+test('PowerShell setup retries a transient deploy.ps1 throw instead of aborting on the first failure', () => {
+  const azLogPath = resolve(scratchDir(), 'az.log');
+  const statusCounterFile = resolve(scratchDir(), 'status-counter');
+  const result = runPowerShell(
+    'setup.ps1',
+    ['-Workload', 'srelabboardshandover'],
+    {
+      LIFECYCLE_AZ_LOG_PATH: azLogPath,
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_CURL_STATUS_COUNTER_FILE: statusCounterFile,
+      LIFECYCLE_CURL_STATUS_PENDING_ATTEMPTS: '2',
+      RETRY_ATTEMPTS: '2',
+      RETRY_DELAY_SECONDS: '0',
+      STATUS_POLL_ATTEMPTS: '2',
+      STATUS_POLL_DELAY_SECONDS: '0',
+    }
+  );
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /Deploy attempt 1 failed; retrying in 0s\./);
+  assert.match(result.stdout, /Timed out after 2 attempts: status endpoint did not report DEPLOYED_COMMIT_SHA=/);
+  assert.equal(
+    readFileSync(azLogPath, 'utf8').match(/functionapp deploy /g)?.length,
+    2,
+    'setup.ps1 should invoke deploy.ps1 twice when the first attempt throws transiently'
+  );
+});
+
 test('Setup seeding v1 controls is idempotent: a repeat call reports already-injected without duplicating', () => {
   const logPath = resolve(scratchDir(), 'curl.log');
   const result = runBash(

--- a/scripts/scenario-tools/test/azure-boards-copilot-handover-lifecycle.test.js
+++ b/scripts/scenario-tools/test/azure-boards-copilot-handover-lifecycle.test.js
@@ -368,6 +368,93 @@ test('Deploy waits (bounded) for the keyed status endpoint to report the deploye
   assert.match(neverSucceeds.stderr, /timed out|did not report/i);
 });
 
+test('Deploy stamps DEPLOYED_COMMIT_SHA and deploys before proving go-live, and only stamps DEPLOYED_AT_UTC after the new SHA is confirmed live (cutover ordering, Bash/PowerShell parity)', () => {
+  const cases = [
+    ['Bash', 'deploy.sh', ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'], runBash],
+    ['PowerShell', 'deploy.ps1', ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'], runPowerShell],
+  ];
+
+  for (const [shell, script, args, run] of cases) {
+    const logPath = resolve(scratchDir(), 'az.log');
+    const result = run(script, args, {
+      LIFECYCLE_AZ_LOG_PATH: logPath,
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+    });
+    assert.equal(result.status, 0, `${shell}: ${result.stderr}\n${result.stdout}`);
+
+    const lines = readFileSync(logPath, 'utf8').split('\n');
+    const shaSettingLineIndex = lines.findIndex((line) =>
+      line.includes(`DEPLOYED_COMMIT_SHA=${localHeadSha}`)
+    );
+    const deployLineIndex = lines.findIndex((line) => line.includes('functionapp deploy'));
+    const atUtcSettingLineIndex = lines.findIndex((line) => line.includes('DEPLOYED_AT_UTC='));
+
+    assert.ok(shaSettingLineIndex >= 0, `${shell}: DEPLOYED_COMMIT_SHA setting missing from az log`);
+    assert.ok(deployLineIndex >= 0, `${shell}: functionapp deploy missing from az log`);
+    assert.ok(atUtcSettingLineIndex >= 0, `${shell}: DEPLOYED_AT_UTC setting missing from az log`);
+
+    assert.ok(
+      shaSettingLineIndex < deployLineIndex,
+      `${shell}: DEPLOYED_COMMIT_SHA must be stamped before the zip is deployed (needed for the go-live poll)`
+    );
+    assert.ok(
+      deployLineIndex < atUtcSettingLineIndex,
+      `${shell}: DEPLOYED_AT_UTC must be stamped only after deploy + the go-live poll confirm the new SHA`
+    );
+    assert.doesNotMatch(
+      lines[shaSettingLineIndex],
+      /DEPLOYED_AT_UTC=/,
+      `${shell}: DEPLOYED_COMMIT_SHA must be stamped on its own settings call, separate from DEPLOYED_AT_UTC`
+    );
+  }
+});
+
+test('Deploy re-confirms (bounded) that the app is coherent after stamping DEPLOYED_AT_UTC, without an unbounded or circular poll', () => {
+  const markerFile = resolve(scratchDir(), 'atutc-marker');
+  const cutoverCounterFile = resolve(scratchDir(), 'cutover-counter');
+
+  const eventuallyCoherent = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_AZ_ATUTC_MARKER_FILE: markerFile,
+      LIFECYCLE_CURL_STATUS_CUTOVER_COUNTER_FILE: cutoverCounterFile,
+      LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_ATTEMPTS: '2',
+      LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_BODY: healthyStatusBody({
+        deployedCommitSha: 'stale-after-cutover-restart',
+      }),
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      STATUS_POLL_ATTEMPTS: '5',
+      STATUS_POLL_DELAY_SECONDS: '0',
+    }
+  );
+  assert.equal(eventuallyCoherent.status, 0, eventuallyCoherent.stderr);
+
+  rmSync(markerFile, { force: true });
+  rmSync(cutoverCounterFile, { force: true });
+
+  const neverCoherent = runBash(
+    'deploy.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_AZ_ATUTC_MARKER_FILE: markerFile,
+      LIFECYCLE_CURL_STATUS_CUTOVER_COUNTER_FILE: cutoverCounterFile,
+      LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_ATTEMPTS: '999',
+      LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_BODY: healthyStatusBody({
+        deployedCommitSha: 'stale-after-cutover-restart',
+      }),
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      STATUS_POLL_ATTEMPTS: '2',
+      STATUS_POLL_DELAY_SECONDS: '0',
+    }
+  );
+  assert.notEqual(neverCoherent.status, 0);
+  assert.match(neverCoherent.stderr, /timed out|did not/i);
+  // Exactly STATUS_POLL_ATTEMPTS cutover-phase status calls were made,
+  // proving the re-poll is bounded rather than unbounded or circular.
+  assert.equal(readFileSync(cutoverCounterFile, 'utf8').trim(), '2');
+});
+
 test('Setup provisions the subscription-scope Bicep template and captures its outputs', () => {
   const bash = readScript('setup.sh');
   const powershell = readScript('setup.ps1');
@@ -541,19 +628,93 @@ test('Validate fails when the receipt split is not exactly 3 v1 and 20 v2', () =
   assert.match(result.stderr, /receipt/i);
 });
 
-test('Validate fails when the incident batch is not yet completed', () => {
-  const result = runBash(
+test('Validate fails when the incident batch is not yet completed, parsing the legitimate JSON false without aborting silently', () => {
+  // `incidentBatchInjected: false` is a legitimate JSON boolean, not a parse
+  // error. `jq -e` treats `false`/`null` output as a jq-level failure, so a
+  // naive `jq -er` under `set -e` (Bash) would abort before ever printing the
+  // SHA comparison lines or emitting the intended diagnostic. Both shells
+  // must parse it, print the diagnostic, and keep going (Bash keeps
+  // aggregating; PowerShell must not terminate on the first Write-Error).
+  for (const [shell, result] of bothShells(
     'validate.sh',
     ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
     {
       LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({ incidentBatchInjected: false }),
       LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
       LIFECYCLE_AZ_QUEUE_DLQ: '0',
       LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
     }
-  );
+  )) {
+    assert.notEqual(result.status, 0, shell);
+    assert.match(
+      result.stderr,
+      /FAIL: the incident batch has not completed \(incidentBatchInjected=false\)/,
+      `${shell}: expected the specific incident-not-completed diagnostic, not just a nonzero exit`
+    );
+    assert.match(
+      result.stdout,
+      /Deployed commit SHA/,
+      `${shell}: script must reach and print the SHA comparison before failing on the incident check`
+    );
+  }
+});
 
-  assert.notEqual(result.status, 0);
+test('Validate aggregates all pre-telemetry failures instead of stopping at the first one (PowerShell parity)', () => {
+  // Bash already aggregates via `failures=$((failures + 1))`. PowerShell's
+  // `Write-Error` under `$ErrorActionPreference = 'Stop'` is a terminating
+  // error, so it must never be used mid-aggregation: it would report only
+  // the first failure and silently drop the rest.
+  for (const [shell, result] of bothShells(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody({
+        deployedCommitSha: 'not-the-local-head',
+        incidentBatchInjected: false,
+        v2ReceiptCount: 19,
+        normalizedReceiptCount: 22,
+      }),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  )) {
+    assert.notEqual(result.status, 0, shell);
+    assert.match(result.stderr, /FAIL: deployed sha/i, `${shell}: missing sha diagnostic`);
+    assert.match(
+      result.stderr,
+      /FAIL: the incident batch has not completed/i,
+      `${shell}: missing incident diagnostic`
+    );
+    assert.match(result.stderr, /FAIL: receipt split/i, `${shell}: missing receipt diagnostic`);
+    assert.match(result.stderr, /\(3 issue\(s\)\)/, `${shell}: missing aggregated failure count`);
+  }
+});
+
+test('Validate aggregates telemetry failures (Service Bus and Application Insights) instead of stopping at the first one (PowerShell parity)', () => {
+  for (const [shell, result] of bothShells(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    ['-ResourceGroup', 'srelabboardshandover-rg', '-AppName', 'test-func'],
+    {
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '4',
+      LIFECYCLE_AZ_QUEUE_DLQ: '2',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '3',
+    }
+  )) {
+    assert.notEqual(result.status, 0, shell);
+    assert.match(result.stderr, /active/i, `${shell}: missing active-message diagnostic`);
+    assert.match(result.stderr, /dead-letter|dlq/i, `${shell}: missing dead-letter diagnostic`);
+    assert.match(
+      result.stderr,
+      /UnsupportedReceiptSchemaError|exception/i,
+      `${shell}: missing exception diagnostic`
+    );
+    assert.match(result.stderr, /\(3 issue\(s\)\)/, `${shell}: missing aggregated failure count`);
+  }
 });
 
 test('Validate fails on non-zero Service Bus active or dead-letter counts', () => {
@@ -598,6 +759,35 @@ test('Validate fails when UnsupportedReceiptSchemaError exceptions occurred afte
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /UnsupportedReceiptSchemaError|exception/i);
+});
+
+test('Validate matches UnsupportedReceiptSchemaError exceptions robustly for module-qualified type names (KQL endswith)', () => {
+  for (const script of ['validate.sh', 'validate.ps1']) {
+    assert.match(
+      readScript(script),
+      /type\s+endswith\s+["']UnsupportedReceiptSchemaError["']/,
+      `${script} should match the exception type with endswith so module-qualified names (e.g. Contoso.Boards.UnsupportedReceiptSchemaError) still count`
+    );
+  }
+
+  const logPath = resolve(scratchDir(), 'az.log');
+  const result = runBash(
+    'validate.sh',
+    ['--resource-group', 'srelabboardshandover-rg', '--app-name', 'test-func'],
+    {
+      LIFECYCLE_AZ_LOG_PATH: logPath,
+      LIFECYCLE_CURL_STATUS_BODY: healthyStatusBody(),
+      LIFECYCLE_AZ_QUEUE_ACTIVE: '0',
+      LIFECYCLE_AZ_QUEUE_DLQ: '0',
+      LIFECYCLE_AZ_EXCEPTION_COUNT: '0',
+    }
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    readFileSync(logPath, 'utf8'),
+    /type endswith 'UnsupportedReceiptSchemaError'/,
+    'the generated analytics query passed to az monitor app-insights query should use endswith'
+  );
 });
 
 test('Validate queries the Service Bus queue and Application Insights explicitly, and fails loudly when either query fails', () => {

--- a/scripts/scenario-tools/test/fixtures/lifecycle-bin/az
+++ b/scripts/scenario-tools/test/fixtures/lifecycle-bin/az
@@ -33,6 +33,87 @@ case " $* " in
     echo 'unexpected CosmosDB role assignment creation' >&2
     exit 99
     ;;
+  *" deployment sub create "*)
+    if [ "${LIFECYCLE_AZ_FAIL_DEPLOYMENT:-}" = "1" ]; then
+      echo 'simulated subscription deployment failure' >&2
+      exit 43
+    fi
+    cat <<JSON
+{
+  "resourceGroupName": {"value": "${LIFECYCLE_AZ_RESOURCE_GROUP_NAME:-srelabboardshandover-rg}"},
+  "functionAppName": {"value": "${LIFECYCLE_AZ_FUNCTION_APP_NAME:-srelabboardshandover-func-abc123}"},
+  "functionAppHostName": {"value": "${LIFECYCLE_AZ_FUNCTION_HOSTNAME:-srelabboardshandover-func-abc123.azurewebsites.net}"},
+  "serviceBusNamespaceName": {"value": "${LIFECYCLE_AZ_SERVICE_BUS_NAMESPACE:-srelabboardshandover-sb-abc123}"},
+  "queueName": {"value": "${LIFECYCLE_AZ_QUEUE_NAME:-order-events}"},
+  "storageAccountName": {"value": "${LIFECYCLE_AZ_STORAGE_ACCOUNT_NAME:-srelabboardshandoverabc123st}"},
+  "applicationInsightsName": {"value": "${LIFECYCLE_AZ_APP_INSIGHTS_NAME:-srelabboardshandover-ai}"}
+}
+JSON
+    ;;
+  *" functionapp keys list "*)
+    if [ -n "${LIFECYCLE_AZ_KEYS_COUNTER_FILE:-}" ]; then
+      attempt=0
+      [ -f "$LIFECYCLE_AZ_KEYS_COUNTER_FILE" ] && attempt=$(cat "$LIFECYCLE_AZ_KEYS_COUNTER_FILE")
+      attempt=$((attempt + 1))
+      printf '%s' "$attempt" > "$LIFECYCLE_AZ_KEYS_COUNTER_FILE"
+      if [ "$attempt" -le "${LIFECYCLE_AZ_KEYS_FAIL_ATTEMPTS:-0}" ]; then
+        echo 'simulated function key propagation delay' >&2
+        exit 44
+      fi
+    fi
+    printf '%s\n' "${LIFECYCLE_AZ_FUNCTION_KEY:-test-function-key}"
+    ;;
+  *" functionapp show "*)
+    printf '%s\n' "${LIFECYCLE_AZ_FUNCTION_HOSTNAME:-srelabboardshandover-func-abc123.azurewebsites.net}"
+    ;;
+  *" functionapp list "*)
+    printf '%s\n' "${LIFECYCLE_AZ_FUNCTION_APP_NAME:-srelabboardshandover-func-abc123}"
+    ;;
+  *" functionapp config appsettings list "*)
+    printf '%s\n' "${LIFECYCLE_AZ_SCM_BUILD_SETTING:-}"
+    ;;
+  *" functionapp config appsettings set "*)
+    if [ "${LIFECYCLE_AZ_FAIL_APPSETTINGS_SET:-}" = "1" ]; then
+      echo 'simulated app settings write failure' >&2
+      exit 45
+    fi
+    ;;
+  *" functionapp deploy "*)
+    if [ "${LIFECYCLE_AZ_FAIL_FUNCTION_DEPLOY:-}" = "1" ]; then
+      echo 'simulated zip deploy failure' >&2
+      exit 46
+    fi
+    ;;
+  *" servicebus namespace list "*)
+    printf '%s\n' "${LIFECYCLE_AZ_SERVICE_BUS_NAMESPACE:-srelabboardshandover-sb-abc123}"
+    ;;
+  *" resource list "*"Microsoft.Insights/components"*)
+    printf '%s\n' "${LIFECYCLE_AZ_APP_INSIGHTS_NAME:-srelabboardshandover-ai}"
+    ;;
+  *" servicebus queue show "*)
+    if [ "${LIFECYCLE_AZ_FAIL_QUEUE_SHOW:-}" = "1" ]; then
+      echo 'simulated Service Bus queue query failure' >&2
+      exit 47
+    fi
+    printf '{"active": %s, "dlq": %s}\n' \
+      "${LIFECYCLE_AZ_QUEUE_ACTIVE:-0}" "${LIFECYCLE_AZ_QUEUE_DLQ:-0}"
+    ;;
+  *" monitor app-insights query "*)
+    if [ "${LIFECYCLE_AZ_FAIL_APP_INSIGHTS_QUERY:-}" = "1" ]; then
+      echo 'simulated Application Insights query failure' >&2
+      exit 48
+    fi
+    printf '{"tables": [{"name": "PrimaryResult", "columns": [{"name": "count_"}], "rows": [[%s]]}]}\n' \
+      "${LIFECYCLE_AZ_EXCEPTION_COUNT:-0}"
+    ;;
+  *" group show "*)
+    if [ "${LIFECYCLE_AZ_GROUP_NOT_FOUND:-}" = "1" ]; then
+      echo 'simulated resource group not found' >&2
+      exit 3
+    fi
+    ;;
+  *" group delete "*)
+    ;;
   *)
     echo "unexpected az command: $*" >&2
     exit 98

--- a/scripts/scenario-tools/test/fixtures/lifecycle-bin/az
+++ b/scripts/scenario-tools/test/fixtures/lifecycle-bin/az
@@ -77,6 +77,11 @@ JSON
       echo 'simulated app settings write failure' >&2
       exit 45
     fi
+    if [ -n "${LIFECYCLE_AZ_ATUTC_MARKER_FILE:-}" ]; then
+      case " $* " in
+        *"DEPLOYED_AT_UTC="*) printf '1' > "$LIFECYCLE_AZ_ATUTC_MARKER_FILE" ;;
+      esac
+    fi
     ;;
   *" functionapp deploy "*)
     if [ "${LIFECYCLE_AZ_FAIL_FUNCTION_DEPLOY:-}" = "1" ]; then

--- a/scripts/scenario-tools/test/fixtures/lifecycle-bin/curl
+++ b/scripts/scenario-tools/test/fixtures/lifecycle-bin/curl
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Fake curl fixture for lifecycle script tests: emulates `curl -sS -o <file> -w
+# '%{http_code}' [-X <method>] <url>` against the keyed HTTP workshop surface
+# (status, submit-v2-orders, seed-v1-controls) without any live Function App.
+set -euo pipefail
+
+output_file=""
+method="GET"
+url=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output_file="$2"; shift 2 ;;
+    -X) method="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -sS|-s|-S|-f) shift ;;
+    http*://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [ -n "${LIFECYCLE_CURL_LOG_PATH:-}" ]; then
+  printf '%s %s\n' "$method" "$url" >> "$LIFECYCLE_CURL_LOG_PATH"
+fi
+
+case "$url" in
+  *"/api/status"*)
+    if [ -n "${LIFECYCLE_CURL_STATUS_COUNTER_FILE:-}" ]; then
+      attempt=0
+      [ -f "$LIFECYCLE_CURL_STATUS_COUNTER_FILE" ] && attempt=$(cat "$LIFECYCLE_CURL_STATUS_COUNTER_FILE")
+      attempt=$((attempt + 1))
+      printf '%s' "$attempt" > "$LIFECYCLE_CURL_STATUS_COUNTER_FILE"
+      if [ "$attempt" -le "${LIFECYCLE_CURL_STATUS_PENDING_ATTEMPTS:-0}" ]; then
+        printf '%s' "${LIFECYCLE_CURL_STATUS_PENDING_BODY:-{\}}" > "$output_file"
+        printf '%s' "${LIFECYCLE_CURL_STATUS_PENDING_CODE:-200}"
+        exit 0
+      fi
+    fi
+    printf '%s' "${LIFECYCLE_CURL_STATUS_BODY:-{\}}" > "$output_file"
+    printf '%s' "${LIFECYCLE_CURL_STATUS_CODE:-200}"
+    ;;
+  *"/api/submit-v2-orders"*)
+    printf '%s' "${LIFECYCLE_CURL_SUBMIT_BODY:-{\"incidentBatchAlreadyInjected\":false,\"eventsEnqueued\":20\}}" > "$output_file"
+    printf '%s' "${LIFECYCLE_CURL_SUBMIT_CODE:-202}"
+    ;;
+  *"/api/seed-v1-controls"*)
+    printf '%s' "${LIFECYCLE_CURL_SEED_BODY:-{\"controlBatchAlreadyInjected\":false,\"eventsEnqueued\":3\}}" > "$output_file"
+    printf '%s' "${LIFECYCLE_CURL_SEED_CODE:-202}"
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 97
+    ;;
+esac

--- a/scripts/scenario-tools/test/fixtures/lifecycle-bin/curl
+++ b/scripts/scenario-tools/test/fixtures/lifecycle-bin/curl
@@ -25,6 +25,22 @@ fi
 
 case "$url" in
   *"/api/status"*)
+    # After the cutover marker exists (the fixture `az` writes it when it sees
+    # a `DEPLOYED_AT_UTC=` app-settings write), simulate the cutover-restart
+    # pending window independently from the earlier go-live pending window,
+    # via its own counter/pending-attempts pair.
+    if [ -n "${LIFECYCLE_AZ_ATUTC_MARKER_FILE:-}" ] && [ -f "${LIFECYCLE_AZ_ATUTC_MARKER_FILE}" ] \
+      && [ -n "${LIFECYCLE_CURL_STATUS_CUTOVER_COUNTER_FILE:-}" ]; then
+      cutover_attempt=0
+      [ -f "$LIFECYCLE_CURL_STATUS_CUTOVER_COUNTER_FILE" ] && cutover_attempt=$(cat "$LIFECYCLE_CURL_STATUS_CUTOVER_COUNTER_FILE")
+      cutover_attempt=$((cutover_attempt + 1))
+      printf '%s' "$cutover_attempt" > "$LIFECYCLE_CURL_STATUS_CUTOVER_COUNTER_FILE"
+      if [ "$cutover_attempt" -le "${LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_ATTEMPTS:-0}" ]; then
+        printf '%s' "${LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_BODY:-{\}}" > "$output_file"
+        printf '%s' "${LIFECYCLE_CURL_STATUS_CUTOVER_PENDING_CODE:-200}"
+        exit 0
+      fi
+    fi
     if [ -n "${LIFECYCLE_CURL_STATUS_COUNTER_FILE:-}" ]; then
       attempt=0
       [ -f "$LIFECYCLE_CURL_STATUS_COUNTER_FILE" ] && attempt=$(cat "$LIFECYCLE_CURL_STATUS_COUNTER_FILE")


### PR DESCRIPTION
## Summary
- add paired Bash and PowerShell setup, deploy, incident injection, recovery validation, and cleanup commands
- add idempotent v1 control seeding plus deployment provenance and receipt-count status fields
- validate exact recovery state and protect participant-only cleanup with credential-free parity tests

## Test plan
- app Ruff format/check, strict mypy, and `pytest` (59 passed; 3 repair tests deselected)
- `pytest -m repair -o addopts=""` (expected: 3 failures, all unsupported v2)
- lifecycle tests (38 passed)
- `npm --prefix scripts/scenario-tools test` (160 passed)
- `scripts/validate-scenarios.sh`
- Bash and PowerShell parsing
- Bicep build

Connected Azure validation was not run; lifecycle behavior is covered by credential-free fake Azure/HTTP fixtures.

Part of #27. Implements #35.