### PR TITLE
feat: configure schema drift incident response

### DIFF
--- a/scenarios/azure-boards-copilot-handover/README.md
+++ b/scenarios/azure-boards-copilot-handover/README.md
@@ -10,10 +10,10 @@ events into receipts. Valid but unsupported v2 order events remain active in
 the queue and create the primary backlog signal. Invalid order events are a
 separate domain concept and are not treated as synonyms for unsupported events.
 
-This capsule's Function application and `setup`/`deploy`/`inject`/`validate`/
-`cleanup` lifecycle scripts are implemented. Investigation assets, the Azure
-Boards learner journey, and connected (live-Azure) validation are delivered
-separately.
+This capsule's Function application, lifecycle scripts, Azure Monitor
+investigation query, and SRE Agent operational guidance are implemented. The
+Azure Boards learner journey and connected (live-Azure) validation are
+delivered separately.
 
 ## Cost profile
 
@@ -31,6 +31,12 @@ application, and seed deterministic v1 control events. `scripts/deploy.sh`/
 incident batch. `scripts/validate.sh`/`.ps1` proves recovery. `scripts/
 cleanup.sh`/`.ps1` deletes only the scenario resource group. The
 infrastructure entry point is `infra/bicep/main.bicep`.
+
+Configure the automatic SRE Agent trigger with
+[Module 4](./docs/04-configure-incident-response.md). The investigation query
+is under [`investigation/`](./investigation/query.kql), and the governed
+diagnosis and recovery contract is under
+[`knowledge/`](./knowledge/operational-guidelines.md).
 
 ## Notes
 

--- a/scenarios/azure-boards-copilot-handover/app/order_events/adapters/service_bus.py
+++ b/scenarios/azure-boards-copilot-handover/app/order_events/adapters/service_bus.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -14,6 +15,8 @@ from order_events.normalizer import (
     UnsupportedReceiptSchemaError,
     normalize_receipt,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class InboundOrderEventMessage(Protocol):
@@ -118,6 +121,19 @@ def process_order_event_message(
         raise
 
     receipt_store.upsert_receipt(receipt, processed_at=clock())
+    logger.info(
+        "Normalized receipt persisted %s",
+        json.dumps(
+            {
+                "order_id": receipt.orderId,
+                "source_schema_version": receipt.sourceSchemaVersion,
+                "customer_id": receipt.customerId,
+                "amount_minor": receipt.amountMinor,
+                "currency": receipt.currency,
+            },
+            sort_keys=True,
+        ),
+    )
 
 
 def _decode_json_body(body: bytes) -> object:

--- a/scenarios/azure-boards-copilot-handover/app/tests/test_service_bus_adapter.py
+++ b/scenarios/azure-boards-copilot-handover/app/tests/test_service_bus_adapter.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from datetime import UTC, datetime
 
 import pytest
@@ -50,6 +52,34 @@ def test_process_order_event_message_persists_supported_receipts() -> None:
             datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC),
         )
     ]
+
+
+def test_process_order_event_message_logs_persisted_receipt_telemetry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO):
+        process_order_event_message(
+            FakeMessage(
+                b'{"schemaVersion":"v1","orderId":"order-1001","customerId":"customer-2001",'
+                b'"total":"12.34","currency":"USD"}'
+            ),
+            receipt_store=FakeReceiptStore(),
+            clock=lambda: datetime(2026, 8, 17, 13, 52, 55, tzinfo=UTC),
+        )
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.message.startswith("Normalized receipt persisted ")
+    )
+    telemetry = json.loads(record.message.removeprefix("Normalized receipt persisted "))
+    assert telemetry == {
+        "amount_minor": 1234,
+        "currency": "USD",
+        "customer_id": "customer-2001",
+        "order_id": "order-1001",
+        "source_schema_version": "v1",
+    }
 
 
 def test_process_order_event_message_delays_and_reraises_unsupported_events() -> None:

--- a/scenarios/azure-boards-copilot-handover/docs/04-configure-incident-response.md
+++ b/scenarios/azure-boards-copilot-handover/docs/04-configure-incident-response.md
@@ -1,0 +1,86 @@
+# Module 4: Configure incident response
+
+Azure Monitor is the incident platform for this scenario. The SRE Agent polls
+Azure Monitor for fired alerts; the capsule does not require an action group,
+webhook, or alert processing rule.
+
+## Connect the scenario resources
+
+In the SRE Agent portal, complete **Full setup** for the scenario resource
+group and connect **Azure Monitor** as the incident platform. Disable or delete
+the default `quickstart` response plan so the same alert is not routed twice.
+
+Confirm the agent can read the resource group, Service Bus metrics, Application
+Insights, and Log Analytics. Use only the portal-managed read permissions for
+investigation; do not grant Azure modification tools. The capsule exports
+Service Bus `AllMetrics` to its Log Analytics workspace so the supplied KQL can
+correlate queue state with Function telemetry.
+
+## Create the investigator
+
+Create a custom agent named `azure-boards-schema-drift-investigator`.
+
+Use these instructions:
+
+> Investigate the Azure Boards Copilot Handover schema-drift incident. Correlate
+> Service Bus active and dead-letter metrics, UnsupportedReceiptSchemaError
+> exceptions, successful normalized-receipt telemetry, and missing v2 receipts.
+> Valid v2 events are unsupported, not invalid. Never edit code, deploy, or
+> change Azure resources. Follow the indexed operational guidelines and require
+> explicit learner approval before any handoff artifact is created.
+
+Index
+`scenarios/azure-boards-copilot-handover/knowledge/operational-guidelines.md`
+as knowledge. Enable only read and investigation tools at this stage.
+
+## Create the automatic response plan
+
+Create one incident response plan:
+
+1. Name: `azure-boards-copilot-handover-review`.
+2. Custom agent: `azure-boards-schema-drift-investigator`.
+3. Severity: **Sev2**.
+4. **Title contains:** `active-message-backlog`.
+5. Autonomy: **Review**.
+6. Keep the default three-hour reinvestigation cooldown enabled.
+7. Confirm the saved plan is **On**.
+
+The deployed alert resource is named
+`<workload>-active-message-backlog`. It monitors the queue's
+`ActiveMessages` metric and is the only automatic trigger for the intended
+exercise.
+
+The separate `<workload>-dead-letter-safety` alert monitors
+`DeadletteredMessages`. Retain it as a safety signal, but do not route it as the
+normal schema-drift trigger. If it fires, stop the expected-path walkthrough
+and investigate why messages exhausted delivery attempts.
+
+## Verify the investigation contract
+
+After injecting the incident, the investigation should show:
+
+- a sustained active backlog;
+- zero dead-lettered messages;
+- `UnsupportedReceiptSchemaError` exceptions;
+- continued `Normalized receipt persisted` traces for v1 controls; and
+- missing v2 rows from `NormalizedReceipts`.
+
+Use [`investigation/query.kql`](../investigation/query.kql) for the Azure
+Monitor evidence. The agent may diagnose and propose the governed handoff, but
+it must not authorize or perform direct remediation.
+
+## Read-only recovery confirmation
+
+After a human reviews, merges, and deploys the Copilot repair, run the capsule
+validator first. Then ask the SRE Agent:
+
+```text
+Perform a read-only recovery confirmation for the Azure Boards Copilot
+Handover incident. Do not modify Azure resources or code, deploy anything, or
+create a work item. Confirm that ActiveMessages returned to zero,
+DeadletteredMessages stayed at zero, UnsupportedReceiptSchemaError exceptions
+stopped after the deployment cutover, and v2 receipt telemetry is present.
+```
+
+Do not close the handoff work item or incident until the deterministic
+validator and this read-only confirmation both succeed.

--- a/scenarios/azure-boards-copilot-handover/infra/bicep/main.bicep
+++ b/scenarios/azure-boards-copilot-handover/infra/bicep/main.bicep
@@ -63,6 +63,7 @@ module messaging 'modules/messaging.bicep' = {
     location: location
     namespaceName: serviceBusNamespaceName
     queueName: queueName
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     tags: tags
   }
 }

--- a/scenarios/azure-boards-copilot-handover/infra/bicep/modules/messaging.bicep
+++ b/scenarios/azure-boards-copilot-handover/infra/bicep/modules/messaging.bicep
@@ -1,6 +1,7 @@
 param location string
 param namespaceName string
 param queueName string
+param logAnalyticsWorkspaceId string
 param tags object
 
 resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
@@ -30,6 +31,20 @@ resource orderEventsQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' = 
     maxSizeInMegabytes: 1024
     requiresDuplicateDetection: false
     requiresSession: false
+  }
+}
+
+resource serviceBusMetrics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: '${namespaceName}-metrics-to-log-analytics'
+  scope: serviceBusNamespace
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
   }
 }
 

--- a/scenarios/azure-boards-copilot-handover/investigation/query.kql
+++ b/scenarios/azure-boards-copilot-handover/investigation/query.kql
@@ -1,0 +1,38 @@
+// Queue state: the intended incident has an active backlog and no dead-lettered messages.
+AzureMetrics
+| where TimeGenerated > ago(1h)
+| where MetricName in ("ActiveMessages", "DeadletteredMessages")
+| extend MetricValue = coalesce(Maximum, Average, Total)
+| project TimeGenerated, ResourceId, MetricName, MetricValue, Tags
+| order by TimeGenerated desc
+
+// Valid v2 events reach the Function but the starting normalizer rejects their schema.
+AppExceptions
+| where TimeGenerated > ago(1h)
+| where
+    ExceptionType endswith "UnsupportedReceiptSchemaError"
+    or OuterMessage has "UnsupportedReceiptSchemaError"
+    or tostring(Details) has "UnsupportedReceiptSchemaError"
+| project TimeGenerated, ExceptionType, OuterMessage, Details, OperationId
+| order by TimeGenerated desc
+
+// Supported controls continue to create receipts while v2 receipt telemetry is absent.
+AppTraces
+| where TimeGenerated > ago(1h)
+| where Message startswith "Normalized receipt persisted "
+| extend telemetry = parse_json(substring(Message, strlen("Normalized receipt persisted ")))
+| extend
+    order_id = tostring(telemetry.order_id),
+    source_schema_version = tostring(telemetry.source_schema_version),
+    customer_id = tostring(telemetry.customer_id),
+    amount_minor = tolong(telemetry.amount_minor),
+    currency = tostring(telemetry.currency)
+| project
+    TimeGenerated,
+    order_id,
+    source_schema_version,
+    customer_id,
+    amount_minor,
+    currency,
+    OperationId
+| order by TimeGenerated desc

--- a/scenarios/azure-boards-copilot-handover/knowledge/operational-guidelines.md
+++ b/scenarios/azure-boards-copilot-handover/knowledge/operational-guidelines.md
@@ -1,0 +1,63 @@
+# Azure Boards Copilot Handover Operational Guidelines
+
+## Purpose
+
+Investigate Service Bus schema drift and preserve the governed handoff. The
+Azure SRE Agent gathers evidence and proposes the next step. It must not edit
+code, create a branch or pull request, deploy an application, or change Azure
+resources during diagnosis or recovery confirmation.
+
+## Incident diagnosis
+
+Treat an order event as **unsupported** when it is valid v2 data that the
+deployed normalizer does not yet understand. Do not describe it as invalid or
+malformed.
+
+Correlate these signals before concluding schema drift:
+
+1. The queue's `ActiveMessages` metric remains above the alert threshold after
+   the 20-event v2 incident batch is submitted.
+2. `DeadletteredMessages` remains zero. The dead-letter alert is a safety
+   signal, not the intended incident trigger.
+3. Application Insights records `UnsupportedReceiptSchemaError` for v2
+   messages.
+4. `AppTraces` contains `Normalized receipt persisted` telemetry for supported
+   v1 controls, including `order_id` and `source_schema_version`.
+5. The `NormalizedReceipts` table has the three v1 control rows but is missing
+   v2 rows.
+
+The combination shows that the Function, queue, and receipt path are operating
+for the supported contract while valid v2 messages remain recoverable in the
+active backlog.
+
+## Safety and handoff boundary
+
+- The active-message backlog alert is the primary automatic SRE Agent trigger.
+- The dead-letter alert requires investigation because the intended path keeps
+  unsupported events active.
+- The SRE Agent must not modify Azure resources or application code.
+- The SRE Agent must ask for explicit learner approval before creating one
+  unassigned Azure Boards Bug. Creating or invoking the Copilot repair is not
+  part of diagnosis.
+- A human invokes Copilot, reviews and merges its pull request, and explicitly
+  deploys the reviewed revision.
+
+## Recovery evidence
+
+The operator-run validator is authoritative for deployment provenance and data
+recovery. It must show the deployed commit matches local `HEAD`, all 23
+receipts exist (3 v1 and 20 v2), and the queue has zero active messages and
+zero dead-letter messages.
+
+After that validator succeeds, perform a separate **read-only recovery
+confirmation** with the SRE Agent. Instruct it not to change Azure resources,
+edit code, deploy, or create another work item. It should confirm:
+
+1. `ActiveMessages` returned to zero after the reviewed deployment.
+2. `DeadletteredMessages` stayed at zero.
+3. New `UnsupportedReceiptSchemaError` exceptions stopped after the deployment
+   cutover.
+4. Receipt telemetry now includes v2 events.
+
+Close the Azure Boards Bug and incident only after both the deterministic
+validator and this read-only confirmation succeed.

--- a/scenarios/azure-boards-copilot-handover/scenario.yaml
+++ b/scenarios/azure-boards-copilot-handover/scenario.yaml
@@ -27,3 +27,5 @@ cleanup:
 signal:
   alertModule: infra/bicep/modules/active-backlog-alert.bicep
   alertName: active-message-backlog
+investigation:
+  query: investigation/query.kql

--- a/scripts/scenario-tools/test/azure-boards-copilot-handover-infrastructure.test.js
+++ b/scripts/scenario-tools/test/azure-boards-copilot-handover-infrastructure.test.js
@@ -44,6 +44,9 @@ test('Azure Boards handover manifest defines the schema-drift signal and scaffol
     alertModule: 'infra/bicep/modules/active-backlog-alert.bicep',
     alertName: 'active-message-backlog',
   });
+  assert.deepEqual(manifest.investigation, {
+    query: 'investigation/query.kql',
+  });
 
   for (const phase of ['setup', 'inject', 'validate', 'cleanup']) {
     assert.equal(manifest[phase].bash, `scripts/${phase}.sh`);
@@ -122,6 +125,10 @@ test('Azure Boards handover provisions managed-identity Function hosting and dat
   assert.match(messaging, /Microsoft\.ServiceBus\/namespaces@/);
   assert.match(messaging, /Microsoft\.ServiceBus\/namespaces\/queues@/);
   assert.match(messaging, /maxDeliveryCount:\s*100/);
+  assert.match(messaging, /Microsoft\.Insights\/diagnosticSettings@/);
+  assert.match(messaging, /workspaceId:\s*logAnalyticsWorkspaceId/);
+  assert.match(messaging, /category:\s*'AllMetrics'/);
+  assert.match(main, /logAnalyticsWorkspaceId:\s*monitoring\.outputs\.logAnalyticsWorkspaceId/);
   assert.match(storage, /Microsoft\.Storage\/storageAccounts@/);
   assert.match(storage, /Microsoft\.Storage\/storageAccounts\/tableServices\/tables@/);
   assert.match(storage, /normalizedreceipts/i);
@@ -188,4 +195,50 @@ test('Azure Boards handover provisions monitoring, primary backlog alert, safety
   ]) {
     assert.match(main, new RegExp(`output ${output} string`));
   }
+});
+
+test('Azure Boards handover investigation correlates backlog, exceptions, and receipt telemetry', () => {
+  const query = readScenarioFile('investigation/query.kql');
+
+  assert.match(query, /AzureMetrics/);
+  assert.match(query, /ActiveMessages/);
+  assert.match(query, /DeadletteredMessages/);
+  assert.match(query, /AppExceptions/);
+  assert.match(query, /UnsupportedReceiptSchemaError/);
+  assert.match(query, /OuterMessage/);
+  assert.match(query, /Details/);
+  assert.match(query, /AppTraces/);
+  assert.match(query, /Normalized receipt persisted/);
+  assert.match(query, /parse_json/);
+  assert.match(query, /source_schema_version/);
+  assert.match(query, /order_id/);
+});
+
+test('Azure Boards handover guidance routes only the primary alert and requires read-only recovery proof', () => {
+  const responsePlan = readScenarioFile('docs/04-configure-incident-response.md');
+  const knowledge = readScenarioFile('knowledge/operational-guidelines.md');
+
+  assert.match(responsePlan, /Azure Monitor[\s\S]*polls/i);
+  assert.match(responsePlan, /azure-boards-copilot-handover-review/);
+  assert.match(responsePlan, /Sev2/);
+  assert.match(responsePlan, /Title contains[\s\S]*active-message-backlog/i);
+  assert.match(responsePlan, /Review/);
+  assert.match(responsePlan, /dead-letter[\s\S]*safety/i);
+  assert.match(responsePlan, /read-only[\s\S]*recovery confirmation/i);
+
+  assert.match(knowledge, /unsupported[\s\S]*valid v2|valid v2[\s\S]*unsupported/i);
+  assert.match(knowledge, /ActiveMessages/);
+  assert.match(knowledge, /UnsupportedReceiptSchemaError/);
+  assert.match(knowledge, /Normalized receipt persisted/);
+  assert.match(
+    knowledge,
+    /NormalizedReceipts[\s\S]*missing[\s\S]*v2|missing[\s\S]*v2[\s\S]*NormalizedReceipts/i,
+  );
+  assert.match(knowledge, /must not[\s\S]*(?:edit|modify)[\s\S]*code/i);
+  assert.match(knowledge, /must not[\s\S]*(?:change|modify)[\s\S]*Azure/i);
+  assert.match(knowledge, /read-only\s+recovery\s+confirmation/i);
+  assert.match(knowledge, /zero active messages/i);
+  assert.match(knowledge, /zero dead-letter/i);
+  assert.match(knowledge, /23[\s\S]*receipts/i);
+  assert.match(knowledge, /UnsupportedReceiptSchemaError[\s\S]*stopped/i);
 });


### PR DESCRIPTION
## Summary

- route the active-message backlog alert into a review-mode SRE Agent response plan while retaining the DLQ safety signal
- export Service Bus metrics to Log Analytics and add resilient KQL for queue, exception, and receipt telemetry
- document governed diagnosis and read-only recovery confirmation without direct remediation

Part of #36

## Validation

- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m mypy function_app.py order_events`
- `python3 -m pytest -q`
- `npm --prefix scripts/scenario-tools test`
- `scripts/validate-scenarios.sh --write`
- `scripts/validate-scenarios.sh`
- `az bicep build --file scenarios/azure-boards-copilot-handover/infra/bicep/main.bicep --stdout`