### PR TITLE
docs: author Azure Boards learner journey

### DIFF
--- a/scenarios/azure-boards-copilot-handover/README.md
+++ b/scenarios/azure-boards-copilot-handover/README.md
@@ -4,16 +4,17 @@
 
 ## Overview
 
-This capsule provides the Azure foundation for a Service Bus schema drift
-incident. A Linux Python Function will eventually normalize supported order
-events into receipts. Valid but unsupported v2 order events remain active in
-the queue and create the primary backlog signal. Invalid order events are a
-separate domain concept and are not treated as synonyms for unsupported events.
+This capsule teaches an end-to-end, approval-gated recovery through Azure SRE
+Agent, Azure Boards, and GitHub Copilot cloud agent. The starting Python
+Function normalizes v1 order events into Table Storage receipts but does not
+understand valid v2 events. The v2 events remain recoverable in Service Bus,
+creating an active backlog without entering the dead-letter queue.
 
-This capsule's Function application, lifecycle scripts, Azure Monitor
-investigation query, and SRE Agent operational guidance are implemented. The
-Azure Boards learner journey and connected (live-Azure) validation are
-delivered separately.
+The SRE Agent investigates the schema drift and, after learner approval,
+creates one unassigned Azure Boards Bug. The learner separately starts Copilot
+from that work item, reviews and merges the linked draft pull request, deploys
+the reviewed revision, and proves recovery through both deterministic
+validation and read-only SRE Agent confirmation.
 
 ## Cost profile
 
@@ -23,24 +24,20 @@ Storage transactions, and Log Analytics/Application Insights ingestion and
 retention. Confirm current pricing for the deployment region before
 provisioning, and run cleanup immediately after completing the scenario.
 
-## Flow
+## Follow the workshop modules
 
-`scripts/setup.sh`/`.ps1` provision infrastructure, deploy the starting
-application, and seed deterministic v1 control events. `scripts/deploy.sh`/
-`.ps1` ship the current checkout. `scripts/inject.sh`/`.ps1` submits the v2
-incident batch. `scripts/validate.sh`/`.ps1` proves recovery. `scripts/
-cleanup.sh`/`.ps1` deletes only the scenario resource group. The
-infrastructure entry point is `infra/bicep/main.bicep`.
+Run every command from the repository root.
 
-Configure the automatic SRE Agent trigger with
-[Module 4](./docs/04-configure-incident-response.md). The investigation query
-is under [`investigation/`](./investigation/query.kql), and the governed
-diagnosis and recovery contract is under
-[`knowledge/`](./knowledge/operational-guidelines.md).
+1. [00 Prerequisites and integration checks](./docs/00-prerequisites.md)
+2. [01 Deploy the starting application](./docs/01-deploy-starting-application.md)
+3. [02 Verify the healthy v1 path](./docs/02-verify-starting-state.md)
+4. [03 Onboard the SRE Agent](./docs/03-onboard-sre-agent.md)
+5. [04 Configure incident response](./docs/04-configure-incident-response.md)
+6. [05 Trigger and investigate schema drift](./docs/05-trigger-and-investigate.md)
+7. [06 Approve the Azure Boards handoff](./docs/06-approve-azure-boards-handoff.md)
+8. [90 Review, deploy, and validate recovery](./docs/90-review-deploy-validate.md)
+9. [99 Close and clean up](./docs/99-cleanup.md)
 
-## Notes
-
-The deployment owns a resource group, Function host storage, two dedicated
-tables, one Service Bus namespace and queue, monitoring resources, and both the
-active-backlog and dead-letter safety alerts. It shares no runtime resources
-with `cloud-agent-handover`.
+This scenario has no simulated, local, or GitHub-issue fallback. It requires
+the real Azure Boards GitHub integration and paid Copilot access because those
+surfaces are the primary learning outcome.

--- a/scenarios/azure-boards-copilot-handover/azure-boards-bug.md
+++ b/scenarios/azure-boards-copilot-handover/azure-boards-bug.md
@@ -1,0 +1,45 @@
+# Azure Boards Bug draft
+
+## Title
+
+Support v2 order events in the receipt normalizer
+
+## Description
+
+The Azure Functions order consumer supports v1 order events but does not
+support valid v2 events. The v2 batch remains recoverable in the Service Bus
+active backlog because the receipt normalizer raises
+`UnsupportedReceiptSchemaError`.
+
+Implement backward-compatible v2 normalization in the existing receipt
+normalizer. Do not change infrastructure, Service Bus or Storage adapters,
+lifecycle scripts, workflows, deployment behavior, or learner documentation.
+
+## Evidence
+
+- `ActiveMessages` remains elevated after the fixed 20-event v2 batch.
+- `DeadletteredMessages` remains zero.
+- Application Insights records `UnsupportedReceiptSchemaError` for v2 events.
+- The three v1 controls continue producing `Normalized receipt persisted`
+  telemetry and Table Storage rows.
+- `NormalizedReceipts` contains no v2 rows before the repair.
+
+## Permitted source scope
+
+- `scenarios/azure-boards-copilot-handover/app/order_events/normalizer/**`
+- `scenarios/azure-boards-copilot-handover/app/tests/test_receipt_normalizer.py`
+- `scenarios/azure-boards-copilot-handover/app/tests/test_repair_v2_normalizer.py`
+
+## Acceptance criteria
+
+- Existing valid v1 events still normalize to the current receipt model.
+- Valid v2 events map `id` to the order id, `customer.id` to the customer id,
+  and `amount.value` / `amount.currency` to the existing amount and currency
+  fields.
+- Both versions persist the correct `sourceSchemaVersion`.
+- Genuinely invalid payloads still raise `InvalidReceiptEventError`; validation
+  is not weakened to accept malformed events.
+- Baseline tests and the v2 repair acceptance tests pass.
+- The repair-scoped normalizer retains 100% branch coverage.
+- The pull request changes only the permitted source scope and remains linked
+  to this Azure Boards Bug.

--- a/scenarios/azure-boards-copilot-handover/docs/00-prerequisites.md
+++ b/scenarios/azure-boards-copilot-handover/docs/00-prerequisites.md
@@ -1,0 +1,100 @@
+# Module 0: Prerequisites and integration checks
+
+This scenario requires live Azure, Azure SRE Agent, Azure Boards, and GitHub
+Copilot cloud agent access. There is no simulated or GitHub-only fallback.
+
+## Facilitator-managed integration
+
+Before a learner starts, a facilitator must provide:
+
+- An Azure DevOps Services organization and project using a process that
+  supports the **Bug** work-item type.
+- The Azure Boards GitHub App installed for the workshop repository.
+- The Azure DevOps project connected to that repository through **GitHub App
+  authentication**. A PAT-backed repository connection does not support the
+  Azure Boards Copilot action.
+- GitHub Copilot cloud agent enabled by organization policy when the
+  repository belongs to a Copilot Business or Enterprise organization.
+
+The facilitator owns this shared connection. Learners must not remove it
+during cleanup.
+
+## Learner access
+
+Confirm that you have:
+
+- An Azure subscription where you can create a resource group, role
+  assignments, Azure Functions, Service Bus, Storage, and monitoring
+  resources.
+- Permission to create and configure an Azure SRE Agent.
+- Azure DevOps **Contributor** access to the workshop project.
+- GitHub **Write** access to the connected repository.
+- An active paid GitHub Copilot plan.
+- Azure CLI, Git, `curl`, `jq`, Python 3.12, and PowerShell 7 when following
+  the PowerShell path.
+- `zip` when following the Bash deployment path.
+
+Sign in and select the intended subscription:
+
+```bash
+az login
+az account show --query '{name:name,id:id}' --output table
+```
+
+```powershell
+az login
+az account show --query '{name:name,id:id}' --output table
+```
+
+## Prepare the application quality tools
+
+The setup helper deploys the current checkout and therefore runs the baseline
+Python gates. Create the scenario-local virtual environment before setup:
+
+```bash
+APP_DIR="scenarios/azure-boards-copilot-handover/app"
+python3 -m venv "$APP_DIR/.venv"
+"$APP_DIR/.venv/bin/python" -m pip install -r "$APP_DIR/requirements-dev.txt"
+```
+
+```powershell
+$AppDir = "scenarios/azure-boards-copilot-handover/app"
+python3 -m venv "$AppDir/.venv"
+& "$AppDir/.venv/bin/python" -m pip install -r "$AppDir/requirements-dev.txt"
+```
+
+These paths target the Linux workshop and Codespaces environment. On native
+Windows, use `.venv\Scripts\python.exe` instead.
+
+Verify the tools:
+
+```bash
+"$APP_DIR/.venv/bin/ruff" --version
+"$APP_DIR/.venv/bin/mypy" --version
+"$APP_DIR/.venv/bin/pytest" --version
+zip -v | head -1
+```
+
+```powershell
+& "$AppDir/.venv/bin/ruff" --version
+& "$AppDir/.venv/bin/mypy" --version
+& "$AppDir/.venv/bin/pytest" --version
+```
+
+## Verify the Azure Boards Copilot action
+
+In the connected Azure DevOps project:
+
+1. Open an eligible existing Bug or create a temporary nonsensitive Bug.
+2. Confirm the **Create a pull request with GitHub Copilot** action is visible.
+3. Open the repository picker and confirm the workshop GitHub repository and
+   `main` branch are available.
+4. Cancel before starting Copilot. The operation cannot be cancelled after it
+   starts.
+5. Delete the temporary Bug if you created one.
+
+Do not put secrets, personal information, access tokens, Function keys, or real
+incident data in a work item. Content passed to Copilot can become visible in
+the linked pull request.
+
+Next: [Deploy the starting application](./01-deploy-starting-application.md).

--- a/scenarios/azure-boards-copilot-handover/docs/01-deploy-starting-application.md
+++ b/scenarios/azure-boards-copilot-handover/docs/01-deploy-starting-application.md
@@ -1,0 +1,53 @@
+# Module 1: Deploy the starting application
+
+Setup provisions the scenario-owned Azure resources, deploys the intentionally
+v1-only Function application from the current checkout, configures alerts, and
+submits three deterministic v1 control events.
+
+## Deploy
+
+Use one shell path.
+
+**Bash**
+
+```bash
+./scenarios/azure-boards-copilot-handover/scripts/setup.sh
+```
+
+**PowerShell 7**
+
+```powershell
+./scenarios/azure-boards-copilot-handover/scripts/setup.ps1
+```
+
+To use a different subscription, region, or workload name, inspect the paired
+help first:
+
+```bash
+./scenarios/azure-boards-copilot-handover/scripts/setup.sh --help
+```
+
+```powershell
+./scenarios/azure-boards-copilot-handover/scripts/setup.ps1 -Help
+```
+
+Keep the printed resource group, Function app, status URL, and submit-v2 URL.
+The URLs contain a placeholder rather than the Function key. Retrieve the key
+only when needed; do not save it in documentation, source control, or an Azure
+Boards work item.
+
+## Confirm the deployed resources
+
+The resource group contains:
+
+- A Linux Python Function app on a Consumption plan.
+- A Service Bus namespace and `order-events` queue.
+- Table Storage for normalized receipts and scenario state.
+- Application Insights and Log Analytics.
+- An active-message backlog alert and a separate dead-letter safety alert.
+
+The Function managed identity has the data-plane access needed for Service Bus
+and the two scenario tables. The deployment shares no runtime resources with
+another workshop capsule.
+
+Next: [Verify the healthy v1 path](./02-verify-starting-state.md).

--- a/scenarios/azure-boards-copilot-handover/docs/02-verify-starting-state.md
+++ b/scenarios/azure-boards-copilot-handover/docs/02-verify-starting-state.md
@@ -1,0 +1,50 @@
+# Module 2: Verify the healthy v1 path
+
+Before triggering schema drift, prove that the queue, Function, and receipt
+store work for the supported v1 contract.
+
+## Open the workshop status
+
+Discover the Function app and retrieve its key without writing the key to
+disk:
+
+```bash
+RESOURCE_GROUP="srelabboardshandover-rg"
+FUNCTION_APP="$(az functionapp list --resource-group "$RESOURCE_GROUP" --query '[0].name' --output tsv)"
+FUNCTION_HOSTNAME="$(az functionapp show --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query defaultHostName --output tsv)"
+FUNCTION_KEY="$(az functionapp keys list --resource-group "$RESOURCE_GROUP" --name "$FUNCTION_APP" --query functionKeys.default --output tsv)"
+curl -sS "https://$FUNCTION_HOSTNAME/api/status?code=$FUNCTION_KEY" | jq
+```
+
+```powershell
+$ResourceGroup = "srelabboardshandover-rg"
+$FunctionApp = az functionapp list --resource-group $ResourceGroup --query "[0].name" --output tsv
+$FunctionHostname = az functionapp show --resource-group $ResourceGroup --name $FunctionApp --query defaultHostName --output tsv
+$FunctionKey = az functionapp keys list --resource-group $ResourceGroup --name $FunctionApp --query functionKeys.default --output tsv
+Invoke-RestMethod "https://$FunctionHostname/api/status?code=$FunctionKey" | ConvertTo-Json
+```
+
+For a custom workload, use `<workload>-rg`.
+
+The healthy starting state is:
+
+```json
+{
+  "incidentBatchInjected": false,
+  "normalizedReceiptCount": 3,
+  "v1ReceiptCount": 3,
+  "v2ReceiptCount": 0
+}
+```
+
+The response also includes deployment provenance. Record the commit SHA, but
+never record the Function key.
+
+## Understand the intended failure
+
+The starting normalizer supports valid v1 events. Valid v2 events use evolved
+field names and nesting, so the normalizer raises
+`UnsupportedReceiptSchemaError`. Those events remain active and recoverable in
+Service Bus. They are **unsupported order events**, not invalid order events.
+
+Next: [Onboard the SRE Agent](./03-onboard-sre-agent.md).

--- a/scenarios/azure-boards-copilot-handover/docs/03-onboard-sre-agent.md
+++ b/scenarios/azure-boards-copilot-handover/docs/03-onboard-sre-agent.md
@@ -1,0 +1,54 @@
+# Module 3: Onboard the SRE Agent
+
+Setup deploys the workload but does not create an Azure SRE Agent. Create or
+select an agent scoped to this scenario before continuing.
+
+## Connect the Azure resources
+
+In [sre.azure.com](https://sre.azure.com):
+
+1. Create an agent for this scenario and select **Set up your agent**.
+2. Add the scenario resource group on the **Azure Resources** card.
+3. Review and finish the portal-managed Reader grant.
+4. Confirm the resource group permission status is complete.
+
+Keep investigation access read-only. Do not grant the agent Azure modification
+tools, deployment actions, or repository write access.
+
+## Connect the GitHub repository
+
+Use the **Code** card to connect this GitHub repository for source
+investigation. The connection lets the agent correlate telemetry with the
+Function normalizer and tests; it does not authorize the agent to edit code or
+open a pull request.
+
+Follow [Connect GitHub to the SRE Agent: Connect your code
+repository](../../../docs/connect-github-to-sre-agent.md#connect-your-code-repository)
+for the current portal flow.
+
+## Add the Azure DevOps connector
+
+Open **Builder → Connectors** and add an **Azure DevOps OAuth connector** for
+the facilitator-provided organization:
+
+1. Choose a connector name such as `ado-workshop`.
+2. Enter the organization name from `https://dev.azure.com/<organization>`.
+3. Use **User account** authentication and sign in with the learner identity.
+4. Review the requested access and add the connector.
+5. Confirm it shows **Connected**.
+
+The connector gives the SRE Agent live work-item access. For this scenario,
+use its write capability only after the learner approves the exact Bug draft.
+The agent must create one unassigned Bug and perform no later tracker write
+without fresh approval.
+
+## Upload operational guidance
+
+Open **Builder → Knowledge base** and add:
+
+[`scenarios/azure-boards-copilot-handover/knowledge/operational-guidelines.md`](../knowledge/operational-guidelines.md)
+
+Wait until `operational-guidelines.md` is indexed. A temporary chat attachment
+does not replace this persistent knowledge source.
+
+Next: [Configure incident response](./04-configure-incident-response.md).

--- a/scenarios/azure-boards-copilot-handover/docs/04-configure-incident-response.md
+++ b/scenarios/azure-boards-copilot-handover/docs/04-configure-incident-response.md
@@ -31,7 +31,11 @@ Use these instructions:
 
 Index
 `scenarios/azure-boards-copilot-handover/knowledge/operational-guidelines.md`
-as knowledge. Enable only read and investigation tools at this stage.
+as knowledge. Enable the Azure DevOps work-item creation operation in addition
+to read and investigation tools. Do not enable repository writes, pull-request
+creation, merge, deployment, or Azure modification operations. The work-item
+operation remains approval-gated by the instructions and response-plan review
+mode.
 
 ## Create the automatic response plan
 
@@ -84,3 +88,5 @@ stopped after the deployment cutover, and v2 receipt telemetry is present.
 
 Do not close the handoff work item or incident until the deterministic
 validator and this read-only confirmation both succeed.
+
+Next: [Trigger and investigate schema drift](./05-trigger-and-investigate.md).

--- a/scenarios/azure-boards-copilot-handover/docs/05-trigger-and-investigate.md
+++ b/scenarios/azure-boards-copilot-handover/docs/05-trigger-and-investigate.md
@@ -1,0 +1,64 @@
+# Module 5: Trigger and investigate schema drift
+
+The learner now submits one deterministic batch of 20 valid v2 order events.
+The operation is idempotent: repeating it does not create another batch.
+
+## Trigger the incident
+
+Use one shell path.
+
+**Bash**
+
+```bash
+./scenarios/azure-boards-copilot-handover/scripts/inject.sh
+```
+
+**PowerShell 7**
+
+```powershell
+./scenarios/azure-boards-copilot-handover/scripts/inject.ps1
+```
+
+The response reports 20 events enqueued for a fresh batch or that the batch
+was already injected. The status still shows three v1 receipts and no v2
+receipts while the intentionally flawed normalizer retries the unsupported
+events.
+
+## Watch the automatic investigation
+
+Wait for Azure Monitor to evaluate the active backlog and for the
+`<workload>-active-message-backlog` Sev2 incident to appear in Azure SRE Agent.
+Open the review-mode investigation.
+
+The diagnosis must correlate:
+
+- A sustained `ActiveMessages` backlog for the 20 v2 events.
+- Zero `DeadletteredMessages`.
+- `UnsupportedReceiptSchemaError` exceptions.
+- Successful `Normalized receipt persisted` traces for the v1 controls.
+- Three v1 rows and no v2 rows in `NormalizedReceipts`.
+
+Use [`investigation/query.kql`](../investigation/query.kql) when you need to
+inspect the evidence directly.
+
+The conclusion should identify **Service Bus schema drift**: the deployed
+consumer remains healthy for supported v1 events, while valid v2 events are
+recoverable but unsupported. Stop if the dead-letter alert fires; that is not
+the intended scenario path.
+
+## Require a proposed handoff before approval
+
+Ask the SRE Agent to prepare, but not create, the handoff:
+
+```text
+Prepare the exact Azure Boards Bug proposed for this Service Bus schema-drift
+incident. Show the title, diagnosis, evidence, permitted source scope, and
+acceptance criteria before taking any write action. Do not create the work
+item until I explicitly approve this displayed draft.
+```
+
+Compare its proposal with
+[`azure-boards-bug.md`](../azure-boards-bug.md). Material differences in the
+diagnosis, scope, or acceptance criteria require correction before approval.
+
+Next: [Approve the Azure Boards handoff](./06-approve-azure-boards-handoff.md).

--- a/scenarios/azure-boards-copilot-handover/docs/06-approve-azure-boards-handoff.md
+++ b/scenarios/azure-boards-copilot-handover/docs/06-approve-azure-boards-handoff.md
@@ -1,0 +1,47 @@
+# Module 6: Approve the Azure Boards handoff
+
+This module contains two independent human gates. Approval to create the Bug
+does not authorize Copilot to change code.
+
+## Gate 1: Approve one Bug
+
+Review the SRE Agent's displayed draft against
+[`azure-boards-bug.md`](../azure-boards-bug.md). Confirm that it:
+
+- Names Service Bus schema drift rather than invalid or malformed messages.
+- Includes the active backlog, zero DLQ, v1 success, schema exception, and
+  missing-v2-receipt evidence.
+- Restricts code changes to the receipt normalizer and its directly related
+  tests.
+- Contains no Function key, token, personal information, or real incident
+  data.
+- Leaves **Assigned To** empty.
+
+Only after the draft matches, approve the single write:
+
+```text
+APPROVE CREATE BUG. Create exactly one unassigned Bug in the connected Azure
+DevOps project using the displayed title and fields. Do not invoke Copilot,
+assign the work item, change its state, add comments, or perform any other
+write after creation.
+```
+
+Open the created Bug and verify the fields. If the SRE Agent proposes a
+materially changed draft or a second work item, do not approve it.
+
+## Gate 2: Start Copilot from Azure Boards
+
+The learner, not the SRE Agent, starts the code modification:
+
+1. In the Bug, select **Create a pull request with GitHub Copilot**.
+2. Choose this connected GitHub repository.
+3. Choose `main` as the base branch.
+4. Keep the work-item content as the task context. Do not broaden the source
+   scope in optional instructions.
+5. Start Copilot only when ready. This operation cannot be cancelled.
+
+Azure Boards passes the Bug title, large text fields, recent comments, and
+work-item link. Copilot creates a linked branch and draft pull request in
+GitHub. The SRE Agent remains read-only after Bug creation.
+
+Next: [Review, deploy, and validate recovery](./90-review-deploy-validate.md).

--- a/scenarios/azure-boards-copilot-handover/docs/90-review-deploy-validate.md
+++ b/scenarios/azure-boards-copilot-handover/docs/90-review-deploy-validate.md
@@ -1,0 +1,130 @@
+# Module 90: Review, deploy, and validate recovery
+
+Copilot produces the repair, but the learner retains merge, deployment,
+validation, and closure authority.
+
+## Review the linked draft pull request
+
+In Azure Boards, watch the Development section move through the Copilot status
+and open the linked GitHub draft pull request.
+
+Confirm that the change is limited to:
+
+- `scenarios/azure-boards-copilot-handover/app/order_events/normalizer/**`
+- `scenarios/azure-boards-copilot-handover/app/tests/test_receipt_normalizer.py`
+- `scenarios/azure-boards-copilot-handover/app/tests/test_repair_v2_normalizer.py`
+
+Reject changes to infrastructure, adapters, lifecycle scripts, workflows,
+learner documentation, or unrelated application code.
+
+The repair must:
+
+- Preserve v1 normalization.
+- Normalize valid v2 `id`, `customer.id`, `amount.value`, and
+  `amount.currency` fields into the existing receipt model.
+- Continue rejecting genuinely invalid events.
+- Make both baseline and repair acceptance tests pass without weakening
+  assertions.
+- Keep the repair-scoped normalizer at 100% branch coverage.
+
+Confirm the pull request contains Azure Boards traceability, including the
+linked work item or its `AB#<id>` reference. Review the diff and required
+checks.
+
+Before merging, check out the pull-request branch and run every repair gate:
+
+```bash
+cd scenarios/azure-boards-copilot-handover/app
+source .venv/bin/activate
+ruff format --check .
+ruff check .
+mypy
+pytest
+pytest -m repair
+pytest --cov=order_events --cov-report=term-missing
+cd ../../..
+```
+
+```powershell
+Set-Location scenarios/azure-boards-copilot-handover/app
+& ./.venv/bin/Activate.ps1
+ruff format --check .
+ruff check .
+mypy
+pytest
+pytest -m repair
+pytest --cov=order_events --cov-report=term-missing
+Set-Location ../../..
+```
+
+The coverage report must show 100% branch coverage for
+`order_events/normalizer`. Merge explicitly only after the pull request is
+ready for review and all checks pass. Merge does not deploy the Function.
+
+## Deploy the reviewed revision
+
+Protect any unrelated local work before changing branches. Then update the
+local default branch:
+
+```bash
+git switch main
+git pull --ff-only
+```
+
+Deploy exactly that checkout.
+
+**Bash**
+
+```bash
+./scenarios/azure-boards-copilot-handover/scripts/deploy.sh
+```
+
+**PowerShell 7**
+
+```powershell
+./scenarios/azure-boards-copilot-handover/scripts/deploy.ps1
+```
+
+The helper reruns the baseline application gates, publishes the current
+checkout, and stamps its Git commit SHA and deployment cutover time. The
+repair acceptance and coverage gates were required separately before merge.
+The helper does not fetch or change branches.
+
+## Deterministic recovery validation
+
+Run one validator path:
+
+**Bash**
+
+```bash
+./scenarios/azure-boards-copilot-handover/scripts/validate.sh
+```
+
+**PowerShell 7**
+
+```powershell
+./scenarios/azure-boards-copilot-handover/scripts/validate.ps1
+```
+
+Success requires:
+
+- The deployed commit SHA equals local `HEAD`.
+- Exactly 23 receipts exist: 3 v1 and 20 v2.
+- Service Bus has zero active and zero dead-lettered messages.
+- No `UnsupportedReceiptSchemaError` occurred after the deployment cutover.
+
+## Read-only SRE Agent confirmation
+
+After the validator succeeds, ask:
+
+```text
+Perform a read-only recovery confirmation for the Azure Boards Copilot
+Handover incident. Do not modify Azure resources or code, deploy anything, or
+create or update a work item. Confirm that ActiveMessages returned to zero,
+DeadletteredMessages stayed at zero, UnsupportedReceiptSchemaError exceptions
+stopped after the deployment cutover, and v2 receipt telemetry is present.
+```
+
+Do not close the Bug or incident unless both validation paths succeed.
+
+Next: [Close and clean up](./99-cleanup.md).

--- a/scenarios/azure-boards-copilot-handover/docs/99-cleanup.md
+++ b/scenarios/azure-boards-copilot-handover/docs/99-cleanup.md
@@ -1,0 +1,49 @@
+# Module 99: Close and clean up
+
+Cleanup separates participant-created artifacts from facilitator-managed
+integration.
+
+## Close the recovery artifacts
+
+Only after deterministic validation and read-only SRE Agent confirmation:
+
+1. Return to the Azure Boards Bug and verify the linked pull request is merged.
+2. Confirm the Bug state reflects the project process; close it manually if
+   merge automation did not.
+3. Close the Azure SRE Agent incident.
+4. Delete the Copilot-created GitHub branch if repository policy did not
+   remove it automatically.
+
+If the pull request was discarded rather than merged, close the Bug with an
+accurate explanation and delete the generated branch.
+
+## Remove participant Azure resources
+
+Use one cleanup path. The script deletes only the scenario resource group.
+
+**Bash**
+
+```bash
+./scenarios/azure-boards-copilot-handover/scripts/cleanup.sh
+```
+
+**PowerShell 7**
+
+```powershell
+./scenarios/azure-boards-copilot-handover/scripts/cleanup.ps1
+```
+
+Delete the learner-created SRE Agent resource separately after confirming you
+no longer need its investigation history.
+
+## Preserve shared integration
+
+Do not:
+
+- Remove the Azure Boards GitHub App installation.
+- Disconnect the Azure DevOps project from the GitHub repository.
+- Delete facilitator-owned Azure DevOps projects or organizations.
+- Revoke organization-level Copilot policy.
+
+Those shared prerequisites belong to the facilitator and support later
+learners.

--- a/scripts/scenario-tools/test/documentation-contract.test.js
+++ b/scripts/scenario-tools/test/documentation-contract.test.js
@@ -486,6 +486,48 @@ test('GitHub integration guide uses current OAuth connector terminology and poli
   assert.doesNotMatch(guide, /GitHub MCP connector/i);
 });
 
+test('Azure Boards handover documentation preserves the approved learner journey', () => {
+  const scenarioRoot = resolve(scenariosRoot, 'azure-boards-copilot-handover');
+  const guide = readFileSync(resolve(scenarioRoot, 'README.md'), 'utf8');
+  const prerequisites = readFileSync(resolve(scenarioRoot, 'docs/00-prerequisites.md'), 'utf8');
+  const onboarding = readFileSync(resolve(scenarioRoot, 'docs/03-onboard-sre-agent.md'), 'utf8');
+  const handoff = readFileSync(
+    resolve(scenarioRoot, 'docs/06-approve-azure-boards-handoff.md'),
+    'utf8',
+  );
+  const recovery = readFileSync(
+    resolve(scenarioRoot, 'docs/90-review-deploy-validate.md'),
+    'utf8',
+  );
+  const cleanup = readFileSync(resolve(scenarioRoot, 'docs/99-cleanup.md'), 'utf8');
+  const bugDraft = readFileSync(resolve(scenarioRoot, 'azure-boards-bug.md'), 'utf8');
+
+  assert.match(guide, /no simulated, local, or GitHub-issue fallback/i);
+  assert.match(prerequisites, /GitHub App[\s*]*authentication/i);
+  assert.match(prerequisites, /paid GitHub Copilot plan/i);
+  assert.match(prerequisites, /Azure DevOps \*\*Contributor\*\*/i);
+  assert.match(prerequisites, /requirements-dev\.txt/i);
+  assert.match(prerequisites, /\bzip\b/i);
+  assert.match(onboarding, /Azure DevOps OAuth connector/i);
+  assert.match(onboarding, /one unassigned Bug/i);
+  assert.match(handoff, /Gate 1[\s\S]*APPROVE CREATE BUG/i);
+  assert.match(handoff, /Gate 2[\s\S]*Create a pull request with GitHub Copilot/i);
+  assert.match(handoff, /cannot be cancelled/i);
+  assert.match(recovery, /normalizer\/\*\*/i);
+  assert.match(recovery, /pytest -m repair/i);
+  assert.match(recovery, /pytest --cov=order_events --cov-report=term-missing/i);
+  assert.match(recovery, /Merge does not deploy/i);
+  assert.match(recovery, /Exactly 23 receipts[\s\S]*3 v1 and 20 v2/i);
+  assert.match(recovery, /read-only SRE Agent confirmation/i);
+  assert.match(cleanup, /Do not[\s\S]*Azure Boards GitHub App installation/i);
+  assert.match(bugDraft, /^## Title$/m);
+  assert.match(bugDraft, /^## Evidence$/m);
+  assert.match(bugDraft, /^## Permitted source scope$/m);
+  assert.match(bugDraft, /^## Acceptance criteria$/m);
+  assert.match(bugDraft, /InvalidReceiptEventError/);
+  assert.doesNotMatch(bugDraft, /Function key|access token|personal information/i);
+});
+
 test('cost guidance rejects the unresolved scaffold marker', () => {
   const guide = `## Cost profile
 


### PR DESCRIPTION
Part of #27

Implements #37.

## Summary
- add the phase-aligned provisioning-to-cleanup learner journey
- add Azure DevOps OAuth and Azure Boards Copilot integration checks
- add the exact approval-gated Azure Boards Bug draft and normalizer-only scope
- document Copilot review, merge, explicit deployment, dual validation, and participant cleanup
- add a documentation contract test for the four human gates and no-fallback boundary

## Validation
- `npm --prefix scripts/scenario-tools test` (163 passed)
- `scripts/validate-scenarios.sh --write`
- `scripts/validate-scenarios.sh`
- `python3 -m pytest -q` (60 passed, 3 deselected)
- `git diff --check`