### PR TITLE
ci: validate Azure Boards handover scenario

### DIFF
--- a/.github/workflows/validate-azure-boards-copilot-handover-app.yml
+++ b/.github/workflows/validate-azure-boards-copilot-handover-app.yml
@@ -1,0 +1,72 @@
+name: Validate Azure Boards Copilot Handover Application
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scenarios/azure-boards-copilot-handover/app/**'
+      - 'scenarios/azure-boards-copilot-handover/CODE_QUALITY.md'
+      - '.github/workflows/validate-azure-boards-copilot-handover-app.yml'
+  pull_request:
+    paths:
+      - 'scenarios/azure-boards-copilot-handover/app/**'
+      - 'scenarios/azure-boards-copilot-handover/CODE_QUALITY.md'
+      - '.github/workflows/validate-azure-boards-copilot-handover-app.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scenarios/azure-boards-copilot-handover/app
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: scenarios/azure-boards-copilot-handover/app/requirements*.txt
+
+      - name: Install quality dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Check formatting
+        run: ruff format --check .
+
+      - name: Lint application
+        run: ruff check .
+
+      - name: Check static types
+        run: mypy
+
+      - name: Run baseline tests with branch coverage
+        run: pytest --cov=order_events --cov-report=term-missing
+
+      - name: Verify the repair acceptance suite is intentionally red
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          set +e
+          pytest -m repair 2>&1 | tee repair-output.txt
+          repair_status="${PIPESTATUS[0]}"
+          set -e
+
+          expected_failures="$(
+            grep -cF "UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported" \
+              repair-output.txt || true
+          )"
+
+          if [[ "$repair_status" -ne 1 ]] ||
+             [[ "$expected_failures" -ne 3 ]] ||
+             ! grep -Eq '^=+ 3 failed, [0-9]+ deselected in [0-9.]+s =+$' \
+               repair-output.txt; then
+            echo "::error::The repair suite must fail only for the three intentionally unsupported v2 events."
+            exit 1
+          fi

--- a/.github/workflows/validate-azure-boards-copilot-handover-app.yml
+++ b/.github/workflows/validate-azure-boards-copilot-handover-app.yml
@@ -59,8 +59,10 @@ jobs:
           set -e
 
           expected_failures="$(
-            grep -cF "UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported" \
-              repair-output.txt || true
+            grep -cF \
+              "E       order_events.normalizer.errors.UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported" \
+              repair-output.txt \
+              || true
           )"
 
           if [[ "$repair_status" -ne 1 ]] ||

--- a/.github/workflows/validate-azure-boards-copilot-handover-infra.yml
+++ b/.github/workflows/validate-azure-boards-copilot-handover-infra.yml
@@ -1,0 +1,52 @@
+name: Validate Azure Boards Copilot Handover Infrastructure
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scenarios/azure-boards-copilot-handover/infra/**'
+      - '.github/workflows/validate-azure-boards-copilot-handover-infra.yml'
+  pull_request:
+    paths:
+      - 'scenarios/azure-boards-copilot-handover/infra/**'
+      - '.github/workflows/validate-azure-boards-copilot-handover-infra.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bicep
+        run: az bicep install
+
+      - name: Validate Bicep syntax
+        run: >-
+          az bicep build --file
+          scenarios/azure-boards-copilot-handover/infra/bicep/main.bicep
+          --stdout >/dev/null
+
+      - name: Verify the invalid workload-name contract
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          bicep_cli="${AZURE_CONFIG_DIR:-$HOME/.azure}/bin/bicep"
+          test_file=scenarios/azure-boards-copilot-handover/infra/bicep/tests/invalid-workload-name.test.bicep
+
+          set +e
+          "$bicep_cli" test "$test_file" 2>&1 | tee bicep-test-output.txt
+          test_status="${PIPESTATUS[0]}"
+          set -e
+
+          if [[ "$test_status" -ne 1 ]] ||
+             ! grep -qF "Evaluation Summary: Failure!" bicep-test-output.txt ||
+             ! grep -qF "workloadName must contain 6-24 lowercase letters, numbers, or hyphens" \
+               bicep-test-output.txt; then
+            echo "::error::The invalid workload-name test did not fail for the expected contract."
+            exit 1
+          fi

--- a/.github/workflows/validate-azure-boards-copilot-handover-infra.yml
+++ b/.github/workflows/validate-azure-boards-copilot-handover-infra.yml
@@ -35,7 +35,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          bicep_cli="${AZURE_CONFIG_DIR:-$HOME/.azure}/bin/bicep"
+          bicep_cli="$(command -v bicep || true)"
+          if [[ -z "$bicep_cli" ]]; then
+            bicep_cli="${AZURE_CONFIG_DIR:-$HOME/.azure}/bin/bicep"
+          fi
+          if [[ ! -x "$bicep_cli" ]]; then
+            echo "::error::Unable to locate the Bicep CLI after installation."
+            exit 1
+          fi
+
           test_file=scenarios/azure-boards-copilot-handover/infra/bicep/tests/invalid-workload-name.test.bicep
 
           set +e

--- a/.github/workflows/validate-scenarios.yml
+++ b/.github/workflows/validate-scenarios.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           node-version: '22'
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: scenarios/azure-boards-copilot-handover/app/requirements*.txt
+
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
@@ -43,6 +49,9 @@ jobs:
       - name: Install scenario-tools
         working-directory: scripts/scenario-tools
         run: npm ci
+
+      - name: Install Azure Boards handover quality dependencies
+        run: pip install -r scenarios/azure-boards-copilot-handover/app/requirements-dev.txt
 
       - name: Unit tests
         working-directory: scripts/scenario-tools

--- a/scenarios/azure-boards-copilot-handover/CODE_QUALITY.md
+++ b/scenarios/azure-boards-copilot-handover/CODE_QUALITY.md
@@ -47,8 +47,10 @@ repair_status="${PIPESTATUS[0]}"
 set -e
 
 expected_failures="$(
-  grep -cF "UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported" \
-    repair-output.txt || true
+  grep -cF \
+    "E       order_events.normalizer.errors.UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported" \
+    repair-output.txt \
+    || true
 )"
 
 if [[ "$repair_status" -ne 1 ]] ||

--- a/scenarios/azure-boards-copilot-handover/CODE_QUALITY.md
+++ b/scenarios/azure-boards-copilot-handover/CODE_QUALITY.md
@@ -10,7 +10,7 @@ the batch pending (and therefore reported as not yet injected) for a later
 retry, and completed batches never re-send duplicates. The quality suite pins
 both constraints.
 
-## Gates
+## Green gates
 
 | Gate | Command | Scope |
 | --- | --- | --- |
@@ -18,13 +18,12 @@ both constraints.
 | Lint | `ruff check .` | Whole `app/` tree |
 | Static types | `mypy` | `function_app.py` and every `order_events` module under global `strict = true` |
 | Baseline tests | `pytest` | Every test except the `repair`-marked acceptance suite, including the incident-batch claim/retry/idempotency regressions |
-| Repair acceptance criteria | `pytest -m repair` | Only the `repair`-marked v2 acceptance suite |
 | Branch coverage | `pytest --cov=order_events --cov-report=term-missing` | `order_events`; the repair-scoped normalizer (`order_events/normalizer`) must stay at 100% |
 
 Run all commands from `scenarios/azure-boards-copilot-handover/app` with the
 project virtual environment active (`pip install -r requirements-dev.txt`).
 
-## The `repair` marker
+## Expected-red starting-state invariant
 
 `tests/test_repair_v2_normalizer.py` is the acceptance criteria for the
 Copilot repair: it asserts that valid v2 order events normalize to the same
@@ -36,16 +35,36 @@ instead of some unrelated bug.
 
 `pyproject.toml` excludes the `repair` marker from the default `pytest`
 invocation (`addopts` includes `-m "not repair"`), so the baseline gate stays
-green. Run the acceptance suite separately:
+green. Before the learner repair, use this exact check to prove that the suite
+is red only for the intended reason:
 
 ```bash
-pytest -m repair
+set -euo pipefail
+
+set +e
+pytest -m repair 2>&1 | tee repair-output.txt
+repair_status="${PIPESTATUS[0]}"
+set -e
+
+expected_failures="$(
+  grep -cF "UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported" \
+    repair-output.txt || true
+)"
+
+if [[ "$repair_status" -ne 1 ]] ||
+   [[ "$expected_failures" -ne 3 ]] ||
+   ! grep -Eq '^=+ 3 failed, [0-9]+ deselected in [0-9.]+s =+$' \
+     repair-output.txt; then
+  echo "The repair suite must fail only for the three intentionally unsupported v2 events." >&2
+  exit 1
+fi
 ```
 
-Before this scenario's repair, that command must fail only with
+The check succeeds only when all three repair tests fail with
 `UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported`. After a
-correct repair, both `pytest` and `pytest -m repair` must pass, and
-`order_events/normalizer` must retain 100% branch coverage.
+correct repair, remove the expected-red check: both `pytest` and
+`pytest -m repair` must pass, and `order_events/normalizer` must retain 100%
+branch coverage.
 
 ## Normalizer repair scope
 
@@ -72,5 +91,6 @@ ruff format --check .
 ruff check .
 mypy
 pytest --cov=order_events --cov-report=term-missing
-pytest -m repair
 ```
+
+Then run the expected-red starting-state check above.

--- a/scenarios/iis-app-pool/tests/approval-gate.test.sh
+++ b/scenarios/iis-app-pool/tests/approval-gate.test.sh
@@ -22,12 +22,25 @@ mkdir -p "$FIXTURE"/{bin,output,scripts/remediation,tools}
 cp "$GATE" "$FIXTURE/tools/invoke-approved-remediation.sh"
 cp "$REMEDIATION" "$FIXTURE/scripts/remediation/start-iis-app-pool.sh"
 
+cat > "$FIXTURE/bin/az" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "account show" ]]; then
+  if [[ " $* " == *" --query name "* ]]; then
+    printf 'test-subscription\n'
+  else
+    printf '00000000-0000-0000-0000-000000000000\n'
+  fi
+fi
+EOF
+
 cat > "$FIXTURE/tools/invoke-vm-run-command.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" > "$FIXTURE/run-command-arguments.txt"
 EOF
 chmod +x \
+  "$FIXTURE/bin/az" \
   "$FIXTURE/tools/invoke-approved-remediation.sh" \
   "$FIXTURE/tools/invoke-vm-run-command.sh" \
   "$FIXTURE/scripts/remediation/start-iis-app-pool.sh"
@@ -35,7 +48,7 @@ chmod +x \
 export FIXTURE
 
 run_gate() {
-  printf '%s\n' "$1" | "$FIXTURE/tools/invoke-approved-remediation.sh" \
+  printf '%s\n' "$1" | PATH="$FIXTURE/bin:$PATH" "$FIXTURE/tools/invoke-approved-remediation.sh" \
     --action start-iis-app-pool \
     --change-ticket CHG-12345 \
     --resource-group rg-test \

--- a/scripts/scenario-tools/test/azure-boards-copilot-handover-workflows.test.js
+++ b/scripts/scenario-tools/test/azure-boards-copilot-handover-workflows.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..');
+const workflowRoot = resolve(repositoryRoot, '.github', 'workflows');
+const scenarioPath = 'scenarios/azure-boards-copilot-handover';
+const qualityGuide = readFileSync(
+  resolve(repositoryRoot, scenarioPath, 'CODE_QUALITY.md'),
+  'utf8',
+);
+
+function readWorkflow(name) {
+  const path = resolve(workflowRoot, name);
+  assert.ok(existsSync(path), `missing workflow: ${name}`);
+  return readFileSync(path, 'utf8');
+}
+
+test('Azure Boards handover application workflow runs every documented quality invariant', () => {
+  const workflow = readWorkflow('validate-azure-boards-copilot-handover-app.yml');
+
+  assert.match(workflow, /name: Validate Azure Boards Copilot Handover Application/);
+  assert.match(workflow, new RegExp(`- '${scenarioPath}/app/\\*\\*'`));
+  assert.match(workflow, new RegExp(`- '${scenarioPath}/CODE_QUALITY\\.md'`));
+  assert.match(workflow, /python-version: '3\.12'/);
+  assert.match(workflow, /pip install -r requirements-dev\.txt/);
+  assert.match(workflow, /ruff format --check \./);
+  assert.match(workflow, /ruff check \./);
+  assert.match(workflow, /run: mypy/);
+  assert.match(workflow, /pytest --cov=order_events --cov-report=term-missing/);
+  assert.match(workflow, /pytest -m repair/);
+  assert.match(workflow, /repair_status="\$\{PIPESTATUS\[0\]\}"/);
+  assert.match(workflow, /\[\[ "\$repair_status" -ne 1 \]\]/);
+  assert.match(workflow, /grep -cF "UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported"/);
+  assert.match(workflow, /\[\[ "\$expected_failures" -ne 3 \]\]/);
+  assert.match(
+    workflow,
+    /grep -Eq '\^=\+ 3 failed, \[0-9\]\+ deselected in \[0-9\.\]\+s =\+\$'/,
+  );
+});
+
+test('Azure Boards handover infrastructure workflow validates the entry point and contract test', () => {
+  const workflow = readWorkflow('validate-azure-boards-copilot-handover-infra.yml');
+
+  assert.match(workflow, /name: Validate Azure Boards Copilot Handover Infrastructure/);
+  assert.match(workflow, new RegExp(`- '${scenarioPath}/infra/\\*\\*'`));
+  assert.match(
+    workflow,
+    new RegExp(
+      `az bicep build --file\\s+${scenarioPath}/infra/bicep/main\\.bicep\\s+--stdout`,
+    ),
+  );
+  assert.match(workflow, /bicep_cli="\$\{AZURE_CONFIG_DIR:-\$HOME\/\.azure\}\/bin\/bicep"/);
+  assert.match(
+    workflow,
+    new RegExp(
+      `test_file=${scenarioPath}/infra/bicep/tests/invalid-workload-name\\.test\\.bicep`,
+    ),
+  );
+  assert.match(workflow, /"\$bicep_cli" test "\$test_file"/);
+  assert.match(workflow, /test_status="\$\{PIPESTATUS\[0\]\}"/);
+  assert.match(workflow, /\[\[ "\$test_status" -ne 1 \]\]/);
+  assert.match(workflow, /grep -qF "Evaluation Summary: Failure!"/);
+});
+
+test('Azure Boards handover quality guide separates green gates from the expected-red invariant', () => {
+  assert.match(qualityGuide, /## Green gates/);
+  assert.match(qualityGuide, /## Expected-red starting-state invariant/);
+  assert.match(qualityGuide, /repair_status="\$\{PIPESTATUS\[0\]\}"/);
+  assert.match(qualityGuide, /\[\[ "\$repair_status" -ne 1 \]\]/);
+  assert.match(qualityGuide, /\[\[ "\$expected_failures" -ne 3 \]\]/);
+  assert.match(
+    qualityGuide,
+    /grep -Eq '\^=\+ 3 failed, \[0-9\]\+ deselected in \[0-9\.\]\+s =\+\$'/,
+  );
+  assert.match(qualityGuide, /The check succeeds only when all three repair tests fail/);
+});

--- a/scripts/scenario-tools/test/azure-boards-copilot-handover-workflows.test.js
+++ b/scripts/scenario-tools/test/azure-boards-copilot-handover-workflows.test.js
@@ -10,6 +10,10 @@ const qualityGuide = readFileSync(
   resolve(repositoryRoot, scenarioPath, 'CODE_QUALITY.md'),
   'utf8',
 );
+const scenarioValidationWorkflow = readFileSync(
+  resolve(workflowRoot, 'validate-scenarios.yml'),
+  'utf8',
+);
 
 function readWorkflow(name) {
   const path = resolve(workflowRoot, name);
@@ -32,7 +36,11 @@ test('Azure Boards handover application workflow runs every documented quality i
   assert.match(workflow, /pytest -m repair/);
   assert.match(workflow, /repair_status="\$\{PIPESTATUS\[0\]\}"/);
   assert.match(workflow, /\[\[ "\$repair_status" -ne 1 \]\]/);
-  assert.match(workflow, /grep -cF "UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported"/);
+  assert.match(workflow, /grep -cF/);
+  assert.match(
+    workflow,
+    /E       order_events\.normalizer\.errors\.UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported/,
+  );
   assert.match(workflow, /\[\[ "\$expected_failures" -ne 3 \]\]/);
   assert.match(
     workflow,
@@ -51,7 +59,9 @@ test('Azure Boards handover infrastructure workflow validates the entry point an
       `az bicep build --file\\s+${scenarioPath}/infra/bicep/main\\.bicep\\s+--stdout`,
     ),
   );
+  assert.match(workflow, /bicep_cli="\$\(command -v bicep \|\| true\)"/);
   assert.match(workflow, /bicep_cli="\$\{AZURE_CONFIG_DIR:-\$HOME\/\.azure\}\/bin\/bicep"/);
+  assert.match(workflow, /\[\[ ! -x "\$bicep_cli" \]\]/);
   assert.match(
     workflow,
     new RegExp(
@@ -72,7 +82,23 @@ test('Azure Boards handover quality guide separates green gates from the expecte
   assert.match(qualityGuide, /\[\[ "\$expected_failures" -ne 3 \]\]/);
   assert.match(
     qualityGuide,
+    /E       order_events\.normalizer\.errors\.UnsupportedReceiptSchemaError: schemaVersion 'v2' is not supported/,
+  );
+  assert.match(
+    qualityGuide,
     /grep -Eq '\^=\+ 3 failed, \[0-9\]\+ deselected in \[0-9\.\]\+s =\+\$'/,
   );
   assert.match(qualityGuide, /The check succeeds only when all three repair tests fail/);
+});
+
+test('global scenario validation installs the handover Python quality dependencies', () => {
+  const pythonSetup = scenarioValidationWorkflow.indexOf('uses: actions/setup-python@v5');
+  const dependencyInstall = scenarioValidationWorkflow.indexOf(
+    'pip install -r scenarios/azure-boards-copilot-handover/app/requirements-dev.txt',
+  );
+  const unitTests = scenarioValidationWorkflow.indexOf('name: Unit tests');
+
+  assert.ok(pythonSetup >= 0);
+  assert.ok(dependencyInstall > pythonSetup);
+  assert.ok(unitTests > dependencyInstall);
 });


### PR DESCRIPTION
## Summary
- add path-scoped application and infrastructure validation workflows
- enforce Python quality, branch coverage, expected-red repair behavior, and Bicep contracts
- document exact local quality commands and pin workflow behavior with scenario-tool tests

## Test plan
- [x] `npm --prefix scripts/scenario-tools test`
- [x] `scripts/validate-scenarios.sh --write`
- [x] `scripts/validate-scenarios.sh`
- [x] Ruff format/check, strict mypy, baseline pytest coverage, and exact expected-red repair verification
- [x] actionlint, Bash syntax, PowerShell parsing, Bicep build, and invalid workload-name contract

Resolves #38